### PR TITLE
Add integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ Thumbs.db
 # other
 .coverage
 .terraform
+.cache
+.parliament-test-es-data

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,10 +72,11 @@ git checkout -b name-of-your-bugfix-or-feature
 7. Before committing, run the quality checks:
 
 ```bash
-make lint      # Check code formatting
-make test      # Run unit tests
-make safe      # Run security checks
-make format    # Format code
+make lint               # Check code formatting
+make test               # Run unit tests
+make test_integration   # Run integration tests (slow on first run)
+make safe               # Run security checks
+make format             # Format code
 ```
 
 8. Test your MCP server changes:

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,9 @@ pre-commit:  ## Run pre-commit on all files
 test: install
 	uv run python -m pytest --cov=parliament_mcp -v --cov-report=term-missing --cov-fail-under=0
 
+test_integration: install
+	uv run python -m pytest -s -v --with-integration
+
 
 run_mcp_server:
 	cd mcp_server && uv run python app/main.py

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,8 @@ test: install
 test_integration: install
 	uv run python -m pytest -s -v --with-integration
 
+test_integration_cleanup:  ## Clean up files created by integration tests
+	rm -rf .cache .pytest_cache tests/.parliament-test-es-data
 
 run_elasticsearch:
 	docker compose up -d elasticsearch --wait

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,9 @@ test_integration: install
 	uv run python -m pytest -s -v --with-integration
 
 
+run_elasticsearch:
+	docker compose up -d elasticsearch --wait
+
 run_mcp_server:
 	cd mcp_server && uv run python app/main.py
 
@@ -64,6 +67,9 @@ load_data_since_2020: init_elasticsearch
 ingest_daily: init_elasticsearch
 	docker compose exec mcp-server uv run parliament-mcp --log-level WARNING load-data hansard --from-date "2 days ago" --to-date "today"
 	docker compose exec mcp-server uv run parliament-mcp --log-level WARNING load-data parliamentary-questions --from-date "2 days ago" --to-date "today"
+
+delete_elasticsearch_data:
+	docker compose exec mcp-server uv run parliament-mcp --log-level WARNING delete-elasticsearch
 
 # MCP Development Commands
 .PHONY: mcp_test

--- a/README.md
+++ b/README.md
@@ -165,11 +165,12 @@ Claude should now have access to the Parliament MCP tools.
 
 3. **Available Make commands**:
    ```bash
-   make install          # Install all dependencies
-   make test            # Run tests
-   make lint            # Check code formatting
-   make format          # Format and fix code
-   make safe            # Run security checks
+   make install           # Install all dependencies
+   make test              # Run tests
+   make test_integration  # Run integration tests (slow on first run)
+   make lint              # Check code formatting
+   make format            # Format and fix code
+   make safe              # Run security checks
 
    # Pre-commit hooks
    make pre-commit-install  # Install pre-commit hooks

--- a/mcp_server/app/utils.py
+++ b/mcp_server/app/utils.py
@@ -7,11 +7,7 @@ from typing import Any
 
 from pydantic.fields import FieldInfo
 
-from parliament_mcp.data_loaders import http_client
-from parliament_mcp.elasticsearch_helpers import get_async_es_client
-from parliament_mcp.settings import settings
-
-es_client = get_async_es_client(settings)
+from parliament_mcp.data_loaders import cached_limited_get
 
 logger = logging.getLogger(__name__)
 
@@ -141,7 +137,7 @@ async def request_members_api(
 
     async with members_api_semaphore:
         try:
-            response = await http_client.get(
+            response = await cached_limited_get(
                 url,
                 headers={
                     "Accept": "application/json",

--- a/mcp_server/pyproject.toml
+++ b/mcp_server/pyproject.toml
@@ -23,6 +23,8 @@ dev = [
     "pytest-asyncio>=1.0.0",
     "openai-agents>=0.0.19",
     "ipykernel>=6.29.5",
+    "testcontainers[elasticsearch]>=4.10.0",
+    "pytest-integration-mark>=0.2.0",
 ]
 
 [build-system]

--- a/mcp_server/tests/conftest.py
+++ b/mcp_server/tests/conftest.py
@@ -1,0 +1,12 @@
+"""Conftest for MCP server tests - imports shared fixtures from root tests directory."""
+
+from tests.conftest import (
+    elasticsearch_container_url,
+    es_test_client,
+)
+
+# Make fixtures available to this test module
+__all__ = [
+    "elasticsearch_container_url",
+    "es_test_client",
+]

--- a/mcp_server/tests/test_elasticsearch_setup.py
+++ b/mcp_server/tests/test_elasticsearch_setup.py
@@ -1,0 +1,40 @@
+"""Test that Elasticsearch test container setup works correctly."""
+
+import pytest
+from elasticsearch import AsyncElasticsearch
+
+from parliament_mcp.settings import settings
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_elasticsearch_indices_exist(es_test_client: AsyncElasticsearch):
+    """Test that the required indices exist with data."""
+    # Check if Parliamentary Questions index exists
+    result = await es_test_client.indices.exists(index=settings.PARLIAMENTARY_QUESTIONS_INDEX)
+    assert result
+
+    # Check if Hansard Contributions index exists
+    assert await es_test_client.indices.exists(index=settings.HANSARD_CONTRIBUTIONS_INDEX)
+
+    # Check that indices have some data
+    pq_count = await es_test_client.count(index=settings.PARLIAMENTARY_QUESTIONS_INDEX)
+    hansard_count = await es_test_client.count(index=settings.HANSARD_CONTRIBUTIONS_INDEX)
+
+    # At least some data should be loaded
+    assert pq_count["count"] > 0
+    assert hansard_count["count"] > 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_elasticsearch_some_data_loaded(es_test_client: AsyncElasticsearch):
+    """Test that basic search functionality works."""
+    # Simple search across all indices
+    result = await es_test_client.search(
+        index=f"{settings.PARLIAMENTARY_QUESTIONS_INDEX},{settings.HANSARD_CONTRIBUTIONS_INDEX}",
+        body={"query": {"match_all": {}}, "size": 5},
+    )
+
+    assert result["hits"]["total"]["value"] > 0
+    assert len(result["hits"]["hits"]) > 0

--- a/mcp_server/tests/test_handlers.py
+++ b/mcp_server/tests/test_handlers.py
@@ -1,93 +1,99 @@
 from datetime import UTC, datetime
 
 import pytest
-import pytest_asyncio
 from elasticsearch import AsyncElasticsearch
 
 from mcp_server.app.handlers import search_debates, search_hansard_contributions, search_parliamentary_questions
-from parliament_mcp.elasticsearch_helpers import get_async_es_client
-from parliament_mcp.settings import ParliamentMCPSettings
-
-
-@pytest.fixture
-def settings():
-    return ParliamentMCPSettings()
-
-
-@pytest_asyncio.fixture
-async def es_client(settings: ParliamentMCPSettings):
-    async with get_async_es_client(settings) as client:
-        yield client
+from parliament_mcp.settings import settings
 
 
 # mark async
 @pytest.mark.asyncio
-async def test_search_parliamentary_questions(settings: ParliamentMCPSettings, es_client: AsyncElasticsearch):
+@pytest.mark.integration
+async def test_search_parliamentary_questions(es_test_client: AsyncElasticsearch):
+    """Test Parliamentary Questions search with test data."""
     results = await search_parliamentary_questions(
-        es_client=es_client, index=settings.PARLIAMENTARY_QUESTIONS_INDEX, dateFrom="2025-06-20", dateTo="2025-06-25"
+        es_client=es_test_client,
+        index=settings.PARLIAMENTARY_QUESTIONS_INDEX,
+        dateFrom="2025-06-20",
+        dateTo="2025-06-25",
     )
     assert results is not None
-    assert len(results) > 0
+    assert len(results) >= 0
 
     results = await search_parliamentary_questions(
-        es_client=es_client,
+        es_client=es_test_client,
         index=settings.PARLIAMENTARY_QUESTIONS_INDEX,
         query="trains and railways",
     )
     assert results is not None
-    assert len(results) > 0
+    # May be 0 if no matching data in test set
+    assert len(results) >= 0
 
 
 @pytest.mark.asyncio
-async def test_search_hansard_contributions(settings: ParliamentMCPSettings, es_client: AsyncElasticsearch):
+@pytest.mark.integration
+async def test_search_hansard_contributions(es_test_client: AsyncElasticsearch):
+    """Test Hansard contributions search with test data."""
+
     results = await search_hansard_contributions(
-        es_client=es_client,
+        es_client=es_test_client,
         index=settings.HANSARD_CONTRIBUTIONS_INDEX,
-        query="trains and railways",
+        query="debate",  # More generic query likely to match test data
     )
     assert results is not None
-    assert len(results) > 0
+    assert len(results) >= 0
 
 
 @pytest.mark.asyncio
-async def test_search_hansard_contributions_with_member_id(
-    settings: ParliamentMCPSettings, es_client: AsyncElasticsearch
-):
+@pytest.mark.integration
+async def test_search_hansard_contributions_with_member_id(es_test_client: AsyncElasticsearch):
+    """Test Hansard contributions search with member ID."""
+
     # Test with a memberId (Keir Starmer)
     results = await search_hansard_contributions(
-        es_client=es_client,
+        es_client=es_test_client,
         index=settings.HANSARD_CONTRIBUTIONS_INDEX,
         memberId=4514,
         maxResults=10,
     )
     assert results is not None
-    assert len(results) > 0
+    assert len(results) >= 0  # May be 0 if this member didn't speak in test data
 
 
 @pytest.mark.asyncio
-async def test_search_debates(settings: ParliamentMCPSettings, es_client: AsyncElasticsearch):
+@pytest.mark.integration
+async def test_search_debates(es_test_client: AsyncElasticsearch):
+    """Test debates search with test data."""
     results = await search_debates(
-        es_client=es_client,
+        es_client=es_test_client,
         index=settings.HANSARD_CONTRIBUTIONS_INDEX,
         date_to="2025-06-25",
     )
     assert results is not None
-    assert len(results) > 0
+    assert len(results) >= 0
 
 
 @pytest.mark.asyncio
-async def test_pmqs_are_on_wednesdays(settings: ParliamentMCPSettings, es_client: AsyncElasticsearch):
+# @pytest.mark.integration
+async def test_pmqs_are_on_wednesdays(es_test_client: AsyncElasticsearch):
+    """Test that PMQs are on Wednesdays."""
     results = await search_debates(
-        es_client=es_client,
+        es_client=es_test_client,
         index=settings.HANSARD_CONTRIBUTIONS_INDEX,
         # Not technically the title of the debate, but good to test with
         query="Prime Minister's Questions",
     )
+    any_pmqs_found = False
     for result in results:
         # If 'Prime Minister' is in debate_parents.Title, then the debate is a PMQs
         is_pmqs = any("Prime Minister" in debate_parent["Title"] for debate_parent in result["debate_parents"])
 
+        any_pmqs_found |= is_pmqs
+
         # PMQs are on Wednesdays
         if is_pmqs:
             date = datetime.fromisoformat(result["date"]).replace(tzinfo=UTC)
-            assert date.weekday() == 2
+            assert date.weekday() == 2, "PMQs found on wrong day"
+
+    assert any_pmqs_found, "No PMQs found in test data"

--- a/mcp_server/tests/test_handlers.py
+++ b/mcp_server/tests/test_handlers.py
@@ -19,7 +19,7 @@ async def test_search_parliamentary_questions(es_test_client: AsyncElasticsearch
         dateTo="2025-06-25",
     )
     assert results is not None
-    assert len(results) >= 0
+    assert len(results) > 0
 
     results = await search_parliamentary_questions(
         es_client=es_test_client,
@@ -28,7 +28,7 @@ async def test_search_parliamentary_questions(es_test_client: AsyncElasticsearch
     )
     assert results is not None
     # May be 0 if no matching data in test set
-    assert len(results) >= 0
+    assert len(results) > 0
 
 
 @pytest.mark.asyncio
@@ -42,7 +42,7 @@ async def test_search_hansard_contributions(es_test_client: AsyncElasticsearch):
         query="debate",  # More generic query likely to match test data
     )
     assert results is not None
-    assert len(results) >= 0
+    assert len(results) > 0
 
 
 @pytest.mark.asyncio
@@ -50,15 +50,15 @@ async def test_search_hansard_contributions(es_test_client: AsyncElasticsearch):
 async def test_search_hansard_contributions_with_member_id(es_test_client: AsyncElasticsearch):
     """Test Hansard contributions search with member ID."""
 
-    # Test with a memberId (Keir Starmer)
+    # Test with a memberId (Deputy PM Angela Rayner stood in for PM in PMQs)
     results = await search_hansard_contributions(
         es_client=es_test_client,
         index=settings.HANSARD_CONTRIBUTIONS_INDEX,
-        memberId=4514,
+        memberId=4356,
         maxResults=10,
     )
     assert results is not None
-    assert len(results) >= 0  # May be 0 if this member didn't speak in test data
+    assert len(results) > 0, "No results found"
 
 
 @pytest.mark.asyncio
@@ -71,11 +71,11 @@ async def test_search_debates(es_test_client: AsyncElasticsearch):
         date_to="2025-06-25",
     )
     assert results is not None
-    assert len(results) >= 0
+    assert len(results) > 0
 
 
 @pytest.mark.asyncio
-# @pytest.mark.integration
+@pytest.mark.integration
 async def test_pmqs_are_on_wednesdays(es_test_client: AsyncElasticsearch):
     """Test that PMQs are on Wednesdays."""
     results = await search_debates(

--- a/mcp_server/uv.lock
+++ b/mcp_server/uv.lock
@@ -46,6 +46,15 @@ wheels = [
 ]
 
 [[package]]
+name = "aiolimiter"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/23/b52debf471f7a1e42e362d959a3982bdcb4fe13a5d46e63d28868807a79c/aiolimiter-1.2.1.tar.gz", hash = "sha256:e02a37ea1a855d9e832252a105420ad4d15011505512a1a1d814647451b5cca9", size = 7185 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/ba/df6e8e1045aebc4778d19b8a3a9bc1808adb1619ba94ca354d9ba17d86c3/aiolimiter-1.2.1-py3-none-any.whl", hash = "sha256:d3f249e9059a20badcb56b61601a83556133655c11d1eb3dd3e04ff069e5f3c7", size = 6711 },
+]
+
+[[package]]
 name = "aiosignal"
 version = "1.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -290,6 +299,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b5/4a/263763cb2ba3816dd94b08ad3a33d5fdae34ecb856678773cc40a3605829/dnspython-2.7.0.tar.gz", hash = "sha256:ce9c432eda0dc91cf618a5cedf1a4e142651196bbcd2c80e89ed5a907e5cfaf1", size = 345197 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/68/1b/e0a87d256e40e8c888847551b20a017a6b98139178505dc7ffb96f04e954/dnspython-2.7.0-py3-none-any.whl", hash = "sha256:b4c34b7d10b51bcc3a5071e7b8dee77939f1e878477eeecc965e9835f63c6c86", size = 313632 },
+]
+
+[[package]]
+name = "docker"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0", size = 147774 },
 ]
 
 [[package]]
@@ -837,6 +860,7 @@ version = "0.1.0"
 source = { editable = "../" }
 dependencies = [
     { name = "aiohttp" },
+    { name = "aiolimiter" },
     { name = "async-lru" },
     { name = "cryptography" },
     { name = "dateparser" },
@@ -853,6 +877,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.12.13" },
+    { name = "aiolimiter", specifier = ">=1.2.1" },
     { name = "async-lru", specifier = ">=2.0.5" },
     { name = "cryptography", specifier = ">=44.0.1" },
     { name = "dateparser", specifier = ">=1.2.1" },
@@ -880,8 +905,11 @@ dev = [
     { name = "pytest-cov", specifier = ">=5.0.0" },
     { name = "pytest-dotenv", specifier = ">=0.5.2" },
     { name = "pytest-env", specifier = ">=1.1.1" },
+    { name = "pytest-integration-mark", specifier = ">=0.2.0" },
     { name = "pytest-mock", specifier = ">=3.14.0" },
     { name = "ruff", specifier = "==0.12.1" },
+    { name = "sentry-sdk", specifier = ">=2.18.0" },
+    { name = "testcontainers", extras = ["elasticsearch"], specifier = ">=4.10.0" },
 ]
 
 [[package]]
@@ -904,6 +932,8 @@ dev = [
     { name = "openai-agents" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-integration-mark" },
+    { name = "testcontainers" },
 ]
 
 [package.metadata]
@@ -923,6 +953,8 @@ dev = [
     { name = "openai-agents", specifier = ">=0.0.19" },
     { name = "pytest", specifier = ">=8.4.1" },
     { name = "pytest-asyncio", specifier = ">=1.0.0" },
+    { name = "pytest-integration-mark", specifier = ">=0.2.0" },
+    { name = "testcontainers", extras = ["elasticsearch"], specifier = ">=4.10.0" },
 ]
 
 [[package]]
@@ -1141,6 +1173,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d0/d4/14f53324cb1a6381bef29d698987625d80052bb33932d8e7cbf9b337b17c/pytest_asyncio-1.0.0.tar.gz", hash = "sha256:d15463d13f4456e1ead2594520216b225a16f781e144f8fdf6c5bb4667c48b3f", size = 46960 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/30/05/ce271016e351fddc8399e546f6e23761967ee09c8c568bbfbecb0c150171/pytest_asyncio-1.0.0-py3-none-any.whl", hash = "sha256:4f024da9f1ef945e680dc68610b52550e36590a67fd31bb3b4943979a1f90ef3", size = 15976 },
+]
+
+[[package]]
+name = "pytest-integration-mark"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/1d/e091051123391bc3b7706c2e2d91f35e448b359fd697967ca93cc2fa99e5/pytest_integration_mark-0.2.0.tar.gz", hash = "sha256:2f3580fba9aa7fecc9ede2385ae5c0c1414c688cc4e8511ccb61f65025508a14", size = 6523 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/29/d7c0776cce4466265fe355faa1b10ffbc14a4b9e7835389aace1ffcbe1f0/pytest_integration_mark-0.2.0-py3-none-any.whl", hash = "sha256:dfff273d47922c2d750923e06ac65bda20ff1c016adba187dee20840f0d5869b", size = 7667 },
 ]
 
 [[package]]
@@ -1410,6 +1454,22 @@ wheels = [
 ]
 
 [[package]]
+name = "testcontainers"
+version = "4.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docker" },
+    { name = "python-dotenv" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/49/9c618aff1c50121d183cdfbc3a4a5cf2727a2cde1893efe6ca55c7009196/testcontainers-4.10.0.tar.gz", hash = "sha256:03f85c3e505d8b4edeb192c72a961cebbcba0dd94344ae778b4a159cb6dcf8d3", size = 63327 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/0a/824b0c1ecf224802125279c3effff2e25ed785ed046e67da6e53d928de4c/testcontainers-4.10.0-py3-none-any.whl", hash = "sha256:31ed1a81238c7e131a2a29df6db8f23717d892b592fa5a1977fd0dcd0c23fc23", size = 107414 },
+]
+
+[[package]]
 name = "tornado"
 version = "6.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1616,6 +1676,26 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ff/83/de1f7709376dc3ca9b7eeb4b9a07b4526b14876b6d372a4dc62312bebee0/websockets-15.0.1-cp312-cp312-win32.whl", hash = "sha256:c338ffa0520bdb12fbc527265235639fb76e7bc7faafbb93f6ba80d9c06578a9", size = 176395 },
     { url = "https://files.pythonhosted.org/packages/7d/71/abf2ebc3bbfa40f391ce1428c7168fb20582d0ff57019b69ea20fa698043/websockets-15.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:fcd5cf9e305d7b8338754470cf69cf81f420459dbae8a3b40cee57417f4614a7", size = 176841 },
     { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743 },
+]
+
+[[package]]
+name = "wrapt"
+version = "1.17.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/fc/e91cc220803d7bc4db93fb02facd8461c37364151b8494762cc88b0fbcef/wrapt-1.17.2.tar.gz", hash = "sha256:41388e9d4d1522446fe79d3213196bd9e3b301a336965b9e27ca2788ebd122f3", size = 55531 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a1/bd/ab55f849fd1f9a58ed7ea47f5559ff09741b25f00c191231f9f059c83949/wrapt-1.17.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d5e2439eecc762cd85e7bd37161d4714aa03a33c5ba884e26c81559817ca0925", size = 53799 },
+    { url = "https://files.pythonhosted.org/packages/53/18/75ddc64c3f63988f5a1d7e10fb204ffe5762bc663f8023f18ecaf31a332e/wrapt-1.17.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3fc7cb4c1c744f8c05cd5f9438a3caa6ab94ce8344e952d7c45a8ed59dd88392", size = 38821 },
+    { url = "https://files.pythonhosted.org/packages/48/2a/97928387d6ed1c1ebbfd4efc4133a0633546bec8481a2dd5ec961313a1c7/wrapt-1.17.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8fdbdb757d5390f7c675e558fd3186d590973244fab0c5fe63d373ade3e99d40", size = 38919 },
+    { url = "https://files.pythonhosted.org/packages/73/54/3bfe5a1febbbccb7a2f77de47b989c0b85ed3a6a41614b104204a788c20e/wrapt-1.17.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5bb1d0dbf99411f3d871deb6faa9aabb9d4e744d67dcaaa05399af89d847a91d", size = 88721 },
+    { url = "https://files.pythonhosted.org/packages/25/cb/7262bc1b0300b4b64af50c2720ef958c2c1917525238d661c3e9a2b71b7b/wrapt-1.17.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d18a4865f46b8579d44e4fe1e2bcbc6472ad83d98e22a26c963d46e4c125ef0b", size = 80899 },
+    { url = "https://files.pythonhosted.org/packages/2a/5a/04cde32b07a7431d4ed0553a76fdb7a61270e78c5fd5a603e190ac389f14/wrapt-1.17.2-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc570b5f14a79734437cb7b0500376b6b791153314986074486e0b0fa8d71d98", size = 89222 },
+    { url = "https://files.pythonhosted.org/packages/09/28/2e45a4f4771fcfb109e244d5dbe54259e970362a311b67a965555ba65026/wrapt-1.17.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6d9187b01bebc3875bac9b087948a2bccefe464a7d8f627cf6e48b1bbae30f82", size = 86707 },
+    { url = "https://files.pythonhosted.org/packages/c6/d2/dcb56bf5f32fcd4bd9aacc77b50a539abdd5b6536872413fd3f428b21bed/wrapt-1.17.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:9e8659775f1adf02eb1e6f109751268e493c73716ca5761f8acb695e52a756ae", size = 79685 },
+    { url = "https://files.pythonhosted.org/packages/80/4e/eb8b353e36711347893f502ce91c770b0b0929f8f0bed2670a6856e667a9/wrapt-1.17.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e8b2816ebef96d83657b56306152a93909a83f23994f4b30ad4573b00bd11bb9", size = 87567 },
+    { url = "https://files.pythonhosted.org/packages/17/27/4fe749a54e7fae6e7146f1c7d914d28ef599dacd4416566c055564080fe2/wrapt-1.17.2-cp312-cp312-win32.whl", hash = "sha256:468090021f391fe0056ad3e807e3d9034e0fd01adcd3bdfba977b6fdf4213ea9", size = 36672 },
+    { url = "https://files.pythonhosted.org/packages/15/06/1dbf478ea45c03e78a6a8c4be4fdc3c3bddea5c8de8a93bc971415e47f0f/wrapt-1.17.2-cp312-cp312-win_amd64.whl", hash = "sha256:ec89ed91f2fa8e3f52ae53cd3cf640d6feff92ba90d62236a81e4e563ac0e991", size = 38865 },
+    { url = "https://files.pythonhosted.org/packages/2d/82/f56956041adef78f849db6b289b282e72b55ab8045a75abad81898c28d19/wrapt-1.17.2-py3-none-any.whl", hash = "sha256:b18f2d1533a71f069c7f82d524a52599053d4c7166e9dd374ae2136b7f40f7c8", size = 23594 },
 ]
 
 [[package]]

--- a/parliament_mcp/cli.py
+++ b/parliament_mcp/cli.py
@@ -7,14 +7,12 @@ import dateparser
 import dotenv
 from rich.logging import RichHandler
 
-from parliament_mcp.data_loaders import ElasticHansardLoader, ElasticParliamentaryQuestionLoader
+from parliament_mcp.data_loaders import load_data
 from parliament_mcp.elasticsearch_helpers import (
-    create_default_index_template_if_none,
-    create_embedding_inference_endpoint_if_none,
-    create_index_if_none,
     delete_index_if_exists,
     delete_inference_endpoint_if_exists,
     get_async_es_client,
+    initialize_elasticsearch_indices,
 )
 from parliament_mcp.settings import ParliamentMCPSettings, settings
 
@@ -49,55 +47,7 @@ async def init_elasticsearch(settings: ParliamentMCPSettings):
     """Initialises Elasticsearch indices."""
     logger.info("Initialising Elasticsearch indices.")
     async with get_async_es_client(settings) as es_client:
-        # Set default index template for single-node cluster
-        await create_default_index_template_if_none(es_client, settings)
-
-        # Create inference endpoints
-        await create_embedding_inference_endpoint_if_none(es_client, settings)
-
-        # Define mappings
-        pq_mapping = {
-            "properties": {
-                "questionText": {
-                    "type": "semantic_text",
-                    "inference_id": settings.EMBEDDING_INFERENCE_ENDPOINT_NAME,
-                },
-                "answerText": {
-                    "type": "semantic_text",
-                    "inference_id": settings.EMBEDDING_INFERENCE_ENDPOINT_NAME,
-                },
-            }
-        }
-
-        hansard_mapping = {
-            "properties": {
-                "ContributionTextFull": {
-                    "type": "semantic_text",
-                    "inference_id": settings.EMBEDDING_INFERENCE_ENDPOINT_NAME,
-                },
-            }
-        }
-
-        # Create indices
-        await create_index_if_none(es_client, settings.PARLIAMENTARY_QUESTIONS_INDEX, pq_mapping)
-        await create_index_if_none(es_client, settings.HANSARD_CONTRIBUTIONS_INDEX, hansard_mapping)
-
-        logger.info("Elasticsearch initialization complete.")
-
-
-async def load_data(settings: ParliamentMCPSettings, source: str, from_date: str, to_date: str):
-    """Load data from specified source into Elasticsearch within date range."""
-    async with get_async_es_client(settings) as elastic_client:
-        if source == "hansard":
-            loader = ElasticHansardLoader(
-                elastic_client=elastic_client, index_name=settings.HANSARD_CONTRIBUTIONS_INDEX
-            )
-            await loader.load_all_contributions(from_date, to_date)
-        elif source == "parliamentary-questions":
-            loader = ElasticParliamentaryQuestionLoader(
-                elastic_client=elastic_client, index_name=settings.PARLIAMENTARY_QUESTIONS_INDEX
-            )
-            await loader.load_questions_for_date_range(from_date, to_date)
+        await initialize_elasticsearch_indices(es_client, settings)
 
 
 def main():

--- a/parliament_mcp/elasticsearch_helpers.py
+++ b/parliament_mcp/elasticsearch_helpers.py
@@ -1,4 +1,6 @@
+import contextlib
 import logging
+from collections.abc import AsyncGenerator
 
 from elasticsearch import AsyncElasticsearch, NotFoundError
 
@@ -7,7 +9,8 @@ from parliament_mcp.settings import ParliamentMCPSettings
 logger = logging.getLogger(__name__)
 
 
-def get_async_es_client(settings: ParliamentMCPSettings) -> AsyncElasticsearch:
+@contextlib.asynccontextmanager
+async def get_async_es_client(settings: ParliamentMCPSettings) -> AsyncGenerator[AsyncElasticsearch]:
     """Gets an async Elasticsearch client from environment variables.
 
     Supports both Elastic Cloud (via cloud_id and api_key) and
@@ -19,10 +22,11 @@ def get_async_es_client(settings: ParliamentMCPSettings) -> AsyncElasticsearch:
             "Connecting to Elasticsearch Cloud with cloud_id: %s",
             settings.ELASTICSEARCH_CLOUD_ID,
         )
-        return AsyncElasticsearch(
+        yield AsyncElasticsearch(
             cloud_id=settings.ELASTICSEARCH_CLOUD_ID,
             api_key=settings.ELASTICSEARCH_API_KEY,
             request_timeout=30,
+            node_class="httpxasync",
         )
     # Fall back to host/port connection
     else:
@@ -32,7 +36,7 @@ def get_async_es_client(settings: ParliamentMCPSettings) -> AsyncElasticsearch:
             settings.ELASTICSEARCH_HOST,
             settings.ELASTICSEARCH_PORT,
         )
-        return AsyncElasticsearch(
+        yield AsyncElasticsearch(
             hosts=[
                 {
                     "scheme": settings.ELASTICSEARCH_SCHEME,
@@ -41,6 +45,7 @@ def get_async_es_client(settings: ParliamentMCPSettings) -> AsyncElasticsearch:
                 }
             ],
             request_timeout=30,
+            node_class="httpxasync",
         )
 
 
@@ -60,16 +65,18 @@ async def inference_exists(es_client: AsyncElasticsearch, inference_id: str) -> 
 
 
 async def create_index_if_none(
-    es_client: AsyncElasticsearch,
-    index_name: str,
-    mappings: dict | str | None = None,
+    es_client: AsyncElasticsearch, index_name: str, mappings: dict | str | None = None, replicas: int = 1
 ):
     """Create Elasticsearch index if it doesn't exist."""
 
     logger.info("Creating index - %s", index_name)
 
     if not await index_exists(es_client, index_name):
-        await es_client.indices.create(index=index_name, mappings=mappings)
+        await es_client.indices.create(
+            index=index_name,
+            mappings=mappings,
+            settings={"number_of_replicas": replicas},
+        )
         logger.info("Created index - %s", index_name)
     else:
         logger.info("Index already exists - %s", index_name)
@@ -156,37 +163,6 @@ async def delete_inference_endpoint_if_exists(es_client: AsyncElasticsearch, inf
         logger.info("Inference endpoint not found - %s", inference_id)
 
 
-async def create_default_index_template_if_none(es_client: AsyncElasticsearch, settings: ParliamentMCPSettings) -> None:
-    """
-    Create a default index template with 0 replicas for single-node clusters.
-
-    Args:
-        es_client: AsyncElasticsearch client
-        settings: ParliamentMCPSettings instance
-    """
-    try:
-        # Check if the default template already exists
-        index_templates = await es_client.indices.get_index_template()
-        if "default_template" in [template["name"] for template in index_templates.get("index_templates", [])]:
-            logger.info("Default index template already exists.")
-            return
-
-        await es_client.indices.put_index_template(
-            name="default_template",
-            body={
-                "index_patterns": ["*"],
-                "priority": 1,
-                "template": {"settings": {"number_of_replicas": settings.ELASTICSEARCH_NUMBER_OF_REPLICAS}},
-            },
-        )
-        logger.info(
-            "Created default index template with %s replicas for single-node cluster.",
-            settings.ELASTICSEARCH_NUMBER_OF_REPLICAS,
-        )
-    except Exception:
-        logger.exception("Failed to create default index template")
-
-
 async def initialize_elasticsearch_indices(
     es_client: AsyncElasticsearch,
     settings: ParliamentMCPSettings,
@@ -202,9 +178,6 @@ async def initialize_elasticsearch_indices(
         settings: ParliamentMCPSettings instance
     """
     logger.info("Initializing Elasticsearch indices")
-
-    # Set default index template for single-node cluster
-    await create_default_index_template_if_none(es_client, settings)
 
     # Create inference endpoints if using semantic text
     await create_embedding_inference_endpoint_if_none(es_client, settings)
@@ -233,7 +206,17 @@ async def initialize_elasticsearch_indices(
     }
 
     # Create indices with appropriate mappings
-    await create_index_if_none(es_client, settings.PARLIAMENTARY_QUESTIONS_INDEX, pq_mapping)
-    await create_index_if_none(es_client, settings.HANSARD_CONTRIBUTIONS_INDEX, hansard_mapping)
+    await create_index_if_none(
+        es_client,
+        settings.PARLIAMENTARY_QUESTIONS_INDEX,
+        pq_mapping,
+        replicas=settings.ELASTICSEARCH_NUMBER_OF_REPLICAS,
+    )
+    await create_index_if_none(
+        es_client,
+        settings.HANSARD_CONTRIBUTIONS_INDEX,
+        hansard_mapping,
+        replicas=settings.ELASTICSEARCH_NUMBER_OF_REPLICAS,
+    )
 
     logger.info("Elasticsearch initialization complete.")

--- a/parliament_mcp/lambda_handler.py
+++ b/parliament_mcp/lambda_handler.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from parliament_mcp import settings
 from parliament_mcp.cli import configure_logging, load_data
+from parliament_mcp.elasticsearch_helpers import get_async_es_client
 from parliament_mcp.settings import ParliamentMCPSettings
 
 # Configure logging
@@ -19,22 +20,25 @@ async def main(settings: ParliamentMCPSettings, from_date_str: str, to_date_str:
     """Main ingestion function that processes all data sources."""
 
     logger.info("Ingesting Hansard data...")
-    await load_data(
-        settings=settings,
-        source="hansard",
-        from_date=from_date_str,
-        to_date=to_date_str,
-    )
-    logger.info("Hansard data ingestion complete.")
+    async with get_async_es_client(settings) as es_client:
+        await load_data(
+            es_client=es_client,
+            settings=settings,
+            source="hansard",
+            from_date=from_date_str,
+            to_date=to_date_str,
+        )
+        logger.info("Hansard data ingestion complete.")
 
-    logger.info("Ingesting Parliamentary Questions data...")
-    await load_data(
-        settings=settings,
-        source="parliamentary-questions",
-        from_date=from_date_str,
-        to_date=to_date_str,
-    )
-    logger.info("Parliamentary Questions data ingestion complete.")
+        logger.info("Ingesting Parliamentary Questions data...")
+        await load_data(
+            es_client=es_client,
+            settings=settings,
+            source="parliamentary-questions",
+            from_date=from_date_str,
+            to_date=to_date_str,
+        )
+        logger.info("Parliamentary Questions data ingestion complete.")
 
 
 def handler(event: dict, _: Any) -> None:

--- a/parliament_mcp/settings.py
+++ b/parliament_mcp/settings.py
@@ -10,7 +10,7 @@ class ParliamentMCPSettings(BaseSettings):
     ENVIRONMENT: str = "local"
     SENTRY_DSN: str | None = None
     AUTH_PROVIDER_PUBLIC_KEY: str | None = None
-    DISABLE_AUTH_SIGNATURE_VERIFICATION: bool | None = ENVIRONMENT in ["local", "integration-test"]
+    DISABLE_AUTH_SIGNATURE_VERIFICATION: bool = ENVIRONMENT == "local"
 
     AZURE_OPENAI_API_KEY: str
     AZURE_OPENAI_ENDPOINT: str

--- a/parliament_mcp/settings.py
+++ b/parliament_mcp/settings.py
@@ -29,6 +29,7 @@ class ParliamentMCPSettings(BaseSettings):
     ELASTICSEARCH_SCHEME: str = "http"
 
     # Set to 0 for single-node cluster
+    ELASTICSEARCH_INDEX_PATTERN: str = "parliament_mcp_*"
     ELASTICSEARCH_NUMBER_OF_REPLICAS: int = 0
 
     EMBEDDING_INFERENCE_ENDPOINT_NAME: str = "openai-embedding-inference"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,9 @@ dev = [
     "ipykernel>=6.29.5",
     "pre-commit>=4.0.0",
     "openai-agents>=0.1.0",
+    "testcontainers[elasticsearch]>=4.10.0",
+    "pytest-integration-mark>=0.2.0",
+    "sentry-sdk>=2.18.0",
 ]
 
 [build-system]
@@ -120,7 +123,7 @@ ignore = ["COM812", "DJ001", "RET505", "RET508", "PLR0913"]
 known-first-party = ["parliament_mcp"]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/*" = ["S101", "S106", "PLR0913", "PLR0915", "PLR2004", "TD003", "S311"]
+"tests/*" = ["S101", "S104", "S106", "PLR0913", "PLR0915", "PLR2004", "TD003", "S311"]
 "*/tests/*" = ["S101", "S106", "PLR0913", "PLR0915", "PLR2004", "TD003"]
 # API files need to match external API parameter names
 "mcp_server/app/api.py" = ["N803", "A002", "E501", "N806"]  # Allow non-snake_case args, shadowing builtins, long lines, and non lowercase variables
@@ -130,3 +133,8 @@ known-first-party = ["parliament_mcp"]
 "parliament_mcp/settings.py" = ["S104", "TD002", "TD003"]  # Allow binding all interfaces, TODO format
 "parliament_mcp/shared_utils/auth.py" = ["E501"]  # Allow longer lines in auth
 "parliament_mcp/cli.py" = ["E501"]  # Allow longer lines in CLI help text
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "session"
+asyncio_default_test_loop_scope = "session"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,8 +51,8 @@ def ensure_docker_connection():
 
     msg = "Failed to connect to Docker. Please check that Docker is running and that the Docker socket is accessible."
     msg += "You can try setting the DOCKER_HOST environment variable to a valid socket path."
-    msg += "For example, on macOS, you can try setting it to /Users/mark.dunne/.docker/run/docker.sock"
-    msg += "or /Users/mark.dunne/.colima/docker.sock"
+    msg += "For example, on macOS, you can try setting it to ~/.docker/run/docker.sock"
+    msg += "or ~/.colima/docker.sock"
     msg += "or /var/run/docker.sock"
     msg += "or /run/docker.sock"
     msg += "or /var/run/docker.sock.1"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,119 @@
+"""Test configuration and fixtures for Parliament MCP tests."""
+
+import logging
+import os
+import warnings
+from collections.abc import AsyncGenerator
+from pathlib import Path
+
+import docker
+import pytest
+import pytest_asyncio
+from elasticsearch import AsyncElasticsearch, Elasticsearch
+from testcontainers.core.waiting_utils import wait_for
+from testcontainers.elasticsearch import ElasticSearchContainer
+
+from parliament_mcp.data_loaders import load_data
+from parliament_mcp.elasticsearch_helpers import initialize_elasticsearch_indices
+from parliament_mcp.settings import settings
+
+logger = logging.getLogger(__name__)
+
+# This is the host port that the container will be bound to.
+ES_CONTAINER_HOST_PORT = 9200
+
+
+def ensure_docker_connection():
+    """Ensure Docker is accessible, trying common socket locations if needed."""
+    # Socket paths to try in order
+    socket_paths = [
+        None,  # Default (let Docker SDK decide)
+        Path.home() / ".docker/run/docker.sock",  # Docker Desktop
+        Path.home() / ".colima/docker.sock",  # Colima
+        Path("/var/run/docker.sock"),  # Standard Linux
+    ]
+
+    for socket_path in socket_paths:
+        if socket_path:
+            if not socket_path.exists():
+                continue
+            os.environ["DOCKER_HOST"] = f"unix://{socket_path}"
+        else:
+            os.environ.pop("DOCKER_HOST", None)
+
+        try:
+            docker.from_env().ping()
+        except docker.errors.DockerException:
+            logger.warning("Failed to connect to Docker at %s", socket_path)
+            continue
+        else:
+            return
+
+    msg = "Failed to connect to Docker. Please check that Docker is running and that the Docker socket is accessible."
+    msg += "You can try setting the DOCKER_HOST environment variable to a valid socket path."
+    msg += "For example, on macOS, you can try setting it to /Users/mark.dunne/.docker/run/docker.sock"
+    msg += "or /Users/mark.dunne/.colima/docker.sock"
+    msg += "or /var/run/docker.sock"
+    msg += "or /run/docker.sock"
+    msg += "or /var/run/docker.sock.1"
+    raise RuntimeError(msg)
+
+
+@pytest.fixture(scope="session")
+async def elasticsearch_container_url() -> AsyncGenerator[str]:
+    """Reusable Elasticsearch container with persistent data volume."""
+    ensure_docker_connection()
+
+    # Create persistent volume path
+    volume_path = Path(__file__).parent / ".parliament-test-es-data"
+    volume_path.mkdir(exist_ok=True)
+
+    # Configure container with persistent volume
+    container = ElasticSearchContainer("docker.elastic.co/elasticsearch/elasticsearch:8.17.3")
+    container.with_env("discovery.type", "single-node")
+    container.with_env("xpack.security.enabled", "false")
+    container.with_env("ES_JAVA_OPTS", "-Xms512m -Xmx512m")
+    container.with_bind_ports(9200, host=ES_CONTAINER_HOST_PORT)
+
+    # create a temporary sync client for the health check
+    es_client = Elasticsearch(f"http://{container.get_container_host_ip()}:{ES_CONTAINER_HOST_PORT}")
+
+    container.with_volume_mapping(host=str(volume_path), container="/usr/share/elasticsearch/data", mode="rw")
+    with container:
+        wait_for(lambda: es_client.cluster.health(wait_for_status="green"))
+        yield f"http://{container.get_container_host_ip()}:{ES_CONTAINER_HOST_PORT}"
+
+
+@pytest_asyncio.fixture(scope="function")
+async def es_test_client(
+    elasticsearch_container_url: str,
+) -> AsyncGenerator[AsyncElasticsearch]:
+    """Elasticsearch client with test data loaded (only loads once per session)."""
+
+    async with AsyncElasticsearch(elasticsearch_container_url, node_class="httpxasync") as es_client:
+        # Check if data already exists
+        if await es_client.indices.exists(index=settings.HANSARD_CONTRIBUTIONS_INDEX):
+            yield es_client
+            return
+
+        # pytest warning (shows with -W flag)
+        warnings.warn(
+            "First-time test setup: Loading Parliamentary data will take 2-5 minutes. "
+            "This only happens once - subsequent runs will be fast.",
+            UserWarning,
+            stacklevel=2,
+        )
+
+        # Initialize Elasticsearch indices and inference endpoints using the shared abstraction
+        # This will try to use semantic_text fields first, but fall back to regular text fields
+        # in test environments if the inference endpoint cannot be created
+        await initialize_elasticsearch_indices(es_client, settings)
+
+        # Load minimal test data
+        # Load Hansard - Monday to Wednesday
+        await load_data(settings, "hansard", "2025-06-23", "2025-06-25")
+
+        # Load Parliamentary Questions - Monday only
+        await load_data(settings, "parliamentary-questions", "2025-06-23", "2025-06-23")
+
+        yield es_client

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -98,10 +98,10 @@ async def es_test_client(
 
         # pytest warning (shows with -W flag)
         warnings.warn(
-            "First-time test setup: Loading Parliamentary data will take 2-5 minutes. "
-            "This only happens once - subsequent runs will be fast.",
+            "First-time test setup: Loading Parliamentary data. This will take a few minutes. "
+            "This only happens once - subsequent runs will be faster.",
             UserWarning,
-            stacklevel=2,
+            stacklevel=0,
         )
 
         # Initialize Elasticsearch indices and inference endpoints using the shared abstraction
@@ -111,9 +111,9 @@ async def es_test_client(
 
         # Load minimal test data
         # Load Hansard - Monday to Wednesday
-        await load_data(settings, "hansard", "2025-06-23", "2025-06-25")
+        await load_data(es_client, settings, "hansard", "2025-06-23", "2025-06-25")
 
         # Load Parliamentary Questions - Monday only
-        await load_data(settings, "parliamentary-questions", "2025-06-23", "2025-06-23")
+        await load_data(es_client, settings, "parliamentary-questions", "2025-06-23", "2025-06-23")
 
         yield es_client

--- a/tests/test_data_loaders.py
+++ b/tests/test_data_loaders.py
@@ -7,14 +7,32 @@ from parliament_mcp.models import DebateParent
 @pytest.mark.asyncio
 async def test_get_debate_parents():
     loader = ElasticHansardLoader(elastic_client=None, index_name="parliament_mcp_hansard_contributions")
-    debate_parents = await loader.get_debate_parents(date="2025-07-08", house="Lords", debate_section_id=4955651)
-    assert len(debate_parents) == 2
+    debate_parents = await loader.get_debate_parents(
+        date="2025-06-25", house="Commons", debate_ext_id="C6A6D738-6043-4D98-81C5-DC9AF7C646E9"
+    )
+    assert len(debate_parents) == 4
+
     assert debate_parents[0] == DebateParent(
-        Id=4955651,
-        Title="Government Performance against Fiscal Rules",
-        ParentId=4955641,
-        ExternalId="1AFCC6ED-CC4E-473E-81A3-1B9A7502A89E",
+        Id=4949262,
+        Title="High-speed Internet",
+        ParentId=4949261,
+        ExternalId="C6A6D738-6043-4D98-81C5-DC9AF7C646E9",
     )
     assert debate_parents[1] == DebateParent(
-        Id=4955641, Title="Lords Chamber", ParentId=None, ExternalId="639d454e-1704-4d26-a1a1-d44f3826b219"
+        Id=4949261,
+        Title="Science, Innovation and Technology",
+        ParentId=4949260,
+        ExternalId="1E65EA07-D2D1-4F38-AA00-6EF0E5E90DE7",
+    )
+    assert debate_parents[2] == DebateParent(
+        Id=4949260,
+        Title="Oral Answers to Questions",
+        ParentId=4949258,
+        ExternalId="39416357-1448-4834-9C24-8C4961253516",
+    )
+    assert debate_parents[3] == DebateParent(
+        Id=4949258,
+        Title="Commons Chamber",
+        ParentId=None,
+        ExternalId="3827400e-4d69-4c77-8be2-3d9fdad192b2",
     )

--- a/tests/test_data_loaders.py
+++ b/tests/test_data_loaders.py
@@ -1,0 +1,20 @@
+import pytest
+
+from parliament_mcp.data_loaders import ElasticHansardLoader
+from parliament_mcp.models import DebateParent
+
+
+@pytest.mark.asyncio
+async def test_get_debate_parents():
+    loader = ElasticHansardLoader(elastic_client=None, index_name="parliament_mcp_hansard_contributions")
+    debate_parents = await loader.get_debate_parents(date="2025-07-08", house="Lords", debate_section_id=4955651)
+    assert len(debate_parents) == 2
+    assert debate_parents[0] == DebateParent(
+        Id=4955651,
+        Title="Government Performance against Fiscal Rules",
+        ParentId=4955641,
+        ExternalId="1AFCC6ED-CC4E-473E-81A3-1B9A7502A89E",
+    )
+    assert debate_parents[1] == DebateParent(
+        Id=4955641, Title="Lords Chamber", ParentId=None, ExternalId="639d454e-1704-4d26-a1a1-d44f3826b219"
+    )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,45 @@
+"""Unit tests for Parliament MCP models."""
+
+from parliament_mcp.models import Contribution
+
+
+def test_contribution_document_uri():
+    """Test that Contribution model computes document URIs correctly."""
+    # Test with ContributionExtId present
+    contribution_with_ext_id = Contribution(
+        DebateSectionExtId="debate-123",
+        ContributionExtId="contrib-456",
+        ContributionText="This is a contribution",
+        OrderInDebateSection=1,
+    )
+    assert contribution_with_ext_id.document_uri == "debate_debate-123_contrib_contrib-456"
+
+    # Test without ContributionExtId - should use hash
+    contribution_without_ext_id = Contribution(
+        DebateSectionExtId="debate-789",
+        ContributionExtId=None,
+        ContributionText="Another contribution",
+        OrderInDebateSection=2,
+    )
+    # Should create a hash-based URI
+    expected_hash = "debate_debate-789_contrib_"
+    assert contribution_without_ext_id.document_uri.startswith(expected_hash)
+    assert len(contribution_without_ext_id.document_uri) > len(expected_hash)
+
+    # Test that same inputs produce same hash
+    contribution_same_inputs = Contribution(
+        DebateSectionExtId="debate-789",
+        ContributionExtId=None,
+        ContributionText="Another contribution",
+        OrderInDebateSection=2,
+    )
+    assert contribution_without_ext_id.document_uri == contribution_same_inputs.document_uri
+
+    # Test that different inputs produce different hashes
+    contribution_different_text = Contribution(
+        DebateSectionExtId="debate-789",
+        ContributionExtId=None,
+        ContributionText="Different contribution",
+        OrderInDebateSection=2,
+    )
+    assert contribution_without_ext_id.document_uri != contribution_different_text.document_uri

--- a/uv.lock
+++ b/uv.lock
@@ -394,6 +394,20 @@ wheels = [
 ]
 
 [[package]]
+name = "docker"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0", size = 147774 },
+]
+
+[[package]]
 name = "elastic-transport"
 version = "8.17.1"
 source = { registry = "https://pypi.org/simple" }
@@ -925,8 +939,11 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-dotenv" },
     { name = "pytest-env" },
+    { name = "pytest-integration-mark" },
     { name = "pytest-mock" },
     { name = "ruff" },
+    { name = "sentry-sdk" },
+    { name = "testcontainers" },
 ]
 
 [package.metadata]
@@ -960,8 +977,11 @@ dev = [
     { name = "pytest-cov", specifier = ">=5.0.0" },
     { name = "pytest-dotenv", specifier = ">=0.5.2" },
     { name = "pytest-env", specifier = ">=1.1.1" },
+    { name = "pytest-integration-mark", specifier = ">=0.2.0" },
     { name = "pytest-mock", specifier = ">=3.14.0" },
     { name = "ruff", specifier = "==0.12.1" },
+    { name = "sentry-sdk", specifier = ">=2.18.0" },
+    { name = "testcontainers", extras = ["elasticsearch"], specifier = ">=4.10.0" },
 ]
 
 [[package]]
@@ -1250,6 +1270,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-integration-mark"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/1d/e091051123391bc3b7706c2e2d91f35e448b359fd697967ca93cc2fa99e5/pytest_integration_mark-0.2.0.tar.gz", hash = "sha256:2f3580fba9aa7fecc9ede2385ae5c0c1414c688cc4e8511ccb61f65025508a14", size = 6523 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/29/d7c0776cce4466265fe355faa1b10ffbc14a4b9e7835389aace1ffcbe1f0/pytest_integration_mark-0.2.0-py3-none-any.whl", hash = "sha256:dfff273d47922c2d750923e06ac65bda20ff1c016adba187dee20840f0d5869b", size = 7667 },
+]
+
+[[package]]
 name = "pytest-mock"
 version = "3.14.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1461,6 +1493,19 @@ wheels = [
 ]
 
 [[package]]
+name = "sentry-sdk"
+version = "2.32.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/10/59/eb90c45cb836cf8bec973bba10230ddad1c55e2b2e9ffa9d7d7368948358/sentry_sdk-2.32.0.tar.gz", hash = "sha256:9016c75d9316b0f6921ac14c8cd4fb938f26002430ac5be9945ab280f78bec6b", size = 334932 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/a1/fc4856bd02d2097324fb7ce05b3021fb850f864b83ca765f6e37e92ff8ca/sentry_sdk-2.32.0-py2.py3-none-any.whl", hash = "sha256:6cf51521b099562d7ce3606da928c473643abe99b00ce4cb5626ea735f4ec345", size = 356122 },
+]
+
+[[package]]
 name = "setuptools"
 version = "80.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1536,6 +1581,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/28/3f/13cacea96900bbd31bb05c6b74135f85d15564fc583802be56976c940470/stevedore-5.4.1.tar.gz", hash = "sha256:3135b5ae50fe12816ef291baff420acb727fcd356106e3e9cbfa9e5985cd6f4b", size = 513858 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/45/8c4ebc0c460e6ec38e62ab245ad3c7fc10b210116cea7c16d61602aa9558/stevedore-5.4.1-py3-none-any.whl", hash = "sha256:d10a31c7b86cba16c1f6e8d15416955fc797052351a56af15e608ad20811fcfe", size = 49533 },
+]
+
+[[package]]
+name = "testcontainers"
+version = "4.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docker" },
+    { name = "python-dotenv" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/49/9c618aff1c50121d183cdfbc3a4a5cf2727a2cde1893efe6ca55c7009196/testcontainers-4.10.0.tar.gz", hash = "sha256:03f85c3e505d8b4edeb192c72a961cebbcba0dd94344ae778b4a159cb6dcf8d3", size = 63327 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/0a/824b0c1ecf224802125279c3effff2e25ed785ed046e67da6e53d928de4c/testcontainers-4.10.0-py3-none-any.whl", hash = "sha256:31ed1a81238c7e131a2a29df6db8f23717d892b592fa5a1977fd0dcd0c23fc23", size = 107414 },
 ]
 
 [[package]]
@@ -1675,6 +1736,26 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6c/63/53559446a878410fc5a5974feb13d31d78d752eb18aeba59c7fef1af7598/wcwidth-0.2.13.tar.gz", hash = "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5", size = 101301 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/84/fd2ba7aafacbad3c4201d395674fc6348826569da3c0937e75505ead3528/wcwidth-0.2.13-py2.py3-none-any.whl", hash = "sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859", size = 34166 },
+]
+
+[[package]]
+name = "wrapt"
+version = "1.17.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/fc/e91cc220803d7bc4db93fb02facd8461c37364151b8494762cc88b0fbcef/wrapt-1.17.2.tar.gz", hash = "sha256:41388e9d4d1522446fe79d3213196bd9e3b301a336965b9e27ca2788ebd122f3", size = 55531 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a1/bd/ab55f849fd1f9a58ed7ea47f5559ff09741b25f00c191231f9f059c83949/wrapt-1.17.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d5e2439eecc762cd85e7bd37161d4714aa03a33c5ba884e26c81559817ca0925", size = 53799 },
+    { url = "https://files.pythonhosted.org/packages/53/18/75ddc64c3f63988f5a1d7e10fb204ffe5762bc663f8023f18ecaf31a332e/wrapt-1.17.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3fc7cb4c1c744f8c05cd5f9438a3caa6ab94ce8344e952d7c45a8ed59dd88392", size = 38821 },
+    { url = "https://files.pythonhosted.org/packages/48/2a/97928387d6ed1c1ebbfd4efc4133a0633546bec8481a2dd5ec961313a1c7/wrapt-1.17.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8fdbdb757d5390f7c675e558fd3186d590973244fab0c5fe63d373ade3e99d40", size = 38919 },
+    { url = "https://files.pythonhosted.org/packages/73/54/3bfe5a1febbbccb7a2f77de47b989c0b85ed3a6a41614b104204a788c20e/wrapt-1.17.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5bb1d0dbf99411f3d871deb6faa9aabb9d4e744d67dcaaa05399af89d847a91d", size = 88721 },
+    { url = "https://files.pythonhosted.org/packages/25/cb/7262bc1b0300b4b64af50c2720ef958c2c1917525238d661c3e9a2b71b7b/wrapt-1.17.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d18a4865f46b8579d44e4fe1e2bcbc6472ad83d98e22a26c963d46e4c125ef0b", size = 80899 },
+    { url = "https://files.pythonhosted.org/packages/2a/5a/04cde32b07a7431d4ed0553a76fdb7a61270e78c5fd5a603e190ac389f14/wrapt-1.17.2-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc570b5f14a79734437cb7b0500376b6b791153314986074486e0b0fa8d71d98", size = 89222 },
+    { url = "https://files.pythonhosted.org/packages/09/28/2e45a4f4771fcfb109e244d5dbe54259e970362a311b67a965555ba65026/wrapt-1.17.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6d9187b01bebc3875bac9b087948a2bccefe464a7d8f627cf6e48b1bbae30f82", size = 86707 },
+    { url = "https://files.pythonhosted.org/packages/c6/d2/dcb56bf5f32fcd4bd9aacc77b50a539abdd5b6536872413fd3f428b21bed/wrapt-1.17.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:9e8659775f1adf02eb1e6f109751268e493c73716ca5761f8acb695e52a756ae", size = 79685 },
+    { url = "https://files.pythonhosted.org/packages/80/4e/eb8b353e36711347893f502ce91c770b0b0929f8f0bed2670a6856e667a9/wrapt-1.17.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e8b2816ebef96d83657b56306152a93909a83f23994f4b30ad4573b00bd11bb9", size = 87567 },
+    { url = "https://files.pythonhosted.org/packages/17/27/4fe749a54e7fae6e7146f1c7d914d28ef599dacd4416566c055564080fe2/wrapt-1.17.2-cp312-cp312-win32.whl", hash = "sha256:468090021f391fe0056ad3e807e3d9034e0fd01adcd3bdfba977b6fdf4213ea9", size = 36672 },
+    { url = "https://files.pythonhosted.org/packages/15/06/1dbf478ea45c03e78a6a8c4be4fdc3c3bddea5c8de8a93bc971415e47f0f/wrapt-1.17.2-cp312-cp312-win_amd64.whl", hash = "sha256:ec89ed91f2fa8e3f52ae53cd3cf640d6feff92ba90d62236a81e4e563ac0e991", size = 38865 },
+    { url = "https://files.pythonhosted.org/packages/2d/82/f56956041adef78f849db6b289b282e72b55ab8045a75abad81898c28d19/wrapt-1.17.2-py3-none-any.whl", hash = "sha256:b18f2d1533a71f069c7f82d524a52599053d4c7166e9dd374ae2136b7f40f7c8", size = 23594 },
 ]
 
 [[package]]


### PR DESCRIPTION
This add integration tests which can be triggered using `make test_integration`.

It uses https://testcontainers-python.readthedocs.io/en/latest/ to setup an Elasticsearch container with some test data