### PR TITLE
Lambda terraform version update

### DIFF
--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -8,7 +8,6 @@ module "parliament_mcp_ingest_lambda" {
   policies                       = [jsonencode(data.aws_iam_policy_document.parliament_mcp_secrets_manager.json)]
   package_type                   = "Image"
   function_name                  = "${local.name}-parliament-mcp-ingest"
-  iam_role_name                  = "${local.name}-parliament-mcp-ingest-lambda-role"
   timeout                        = 900
   memory_size                    = 1024
   aws_security_group_ids         = [aws_security_group.parliament_mcp_security_group.id]

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -1,5 +1,5 @@
 module "parliament_mcp_ingest_lambda" {
-  source = "git::https://github.com/i-dot-ai/i-dot-ai-core-terraform-modules.git//modules/infrastructure/lambda?ref=v1.2.0-lambda"
+  source = "git::https://github.com/i-dot-ai/i-dot-ai-core-terraform-modules.git//modules/infrastructure/lambda?ref=v2.0.1-lambda"
 
   image_uri = "${data.aws_caller_identity.current.account_id}.dkr.ecr.${var.region}.amazonaws.com/parliament-mcp-lambda:${var.image_tag}"
   image_config = {


### PR DESCRIPTION
- Updates the version from v1.2.0 -> v2.0.1
- Removes 'iam_role_name' which is no longer a supported parameter