### PR TITLE
Add healthcheck endpoint to fix ECS container restarts

### DIFF
--- a/parliament_mcp/mcp_server/main.py
+++ b/parliament_mcp/mcp_server/main.py
@@ -2,6 +2,7 @@ import contextlib
 
 import uvicorn
 from fastapi import FastAPI
+from fastapi.responses import JSONResponse
 
 from parliament_mcp.mcp_server.api import mcp_server, settings
 
@@ -17,6 +18,10 @@ def create_app():
 
     app = FastAPI(lifespan=lifespan)
     app.mount(settings.MCP_ROOT_PATH, mcp_server.streamable_http_app())
+
+    @app.get("/healthcheck")
+    async def health_check():
+        return JSONResponse(status_code=200, content={"status": "ok"})
 
     return app
 


### PR DESCRIPTION
The ECS service was configured to check /healthcheck but the endpoint was missing, causing containers to be marked unhealthy and restart continuously. 

Added the endpoint to the main FastAPI app to return HTTP 200 with {"status": "ok"}.