### PR TITLE
Feature/lambda env vars

### DIFF
--- a/parliament_mcp/lambda_handler.py
+++ b/parliament_mcp/lambda_handler.py
@@ -4,10 +4,9 @@ import os
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
-from parliament_mcp import settings
 from parliament_mcp.cli import configure_logging, load_data
 from parliament_mcp.elasticsearch_helpers import get_async_es_client
-from parliament_mcp.settings import ParliamentMCPSettings
+from parliament_mcp.settings import ParliamentMCPSettings, settings
 
 # Configure logging
 logger = logging.getLogger(__name__)

--- a/parliament_mcp/settings.py
+++ b/parliament_mcp/settings.py
@@ -38,7 +38,7 @@ class ParliamentMCPSettings(BaseSettings):
 
     APP_NAME: str
     AWS_ACCOUNT_ID: str | None = None
-    AWS_REGION: str
+    AWS_REGION: str = "eu-west-2"
     ENVIRONMENT: str = "local"
 
     # Use SSM for sensitive parameters in AWS environments

--- a/parliament_mcp/settings.py
+++ b/parliament_mcp/settings.py
@@ -36,9 +36,9 @@ def get_environment_or_ssm(env_var_name: str, ssm_path: str | None = None, defau
 class ParliamentMCPSettings(BaseSettings):
     """Configuration settings for Parliament MCP application with environment-based loading."""
 
-    APP_NAME: str = "parliament-mcp"
+    APP_NAME: str
     AWS_ACCOUNT_ID: str | None = None
-    AWS_REGION: str = "eu-west-2"
+    AWS_REGION: str
     ENVIRONMENT: str = "local"
 
     # Use SSM for sensitive parameters in AWS environments

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,7 +134,7 @@ known-first-party = ["parliament_mcp"]
 "parliament_mcp/mcp_server/handlers.py" = ["N803", "A001"]  # Allow non-snake_case args and shadowing builtins
 "parliament_mcp/mcp_server/main.py" = ["ARG001"]  # Allow unused args in FastAPI lifespan
 "parliament_mcp/models.py" = ["N815", "FURB162"]  # Allow mixedCase, timezone handling
-"parliament_mcp/settings.py" = ["S104", "TD002", "TD003"]  # Allow binding all interfaces, TODO format
+"parliament_mcp/settings.py" = ["S104", "TD002", "TD003", "N802"]  # Allow binding all interfaces, TODO format, uppercase property names for settings
 "parliament_mcp/shared_utils/auth.py" = ["E501"]  # Allow longer lines in auth
 "parliament_mcp/cli.py" = ["E501", "PLC0415"]  # Allow longer lines in CLI help text, allow imports not at top of file
 

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -20,7 +20,6 @@ module "parliament_mcp_ingest_lambda" {
 
   environment_variables = {
     APP_NAME = "${local.name}-parliament-mcp-ingest"
-    AWS_REGION = var.region
     ENVIRONMENT = terraform.workspace
     PROJECT_NAME = local.name
   }

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -41,9 +41,10 @@ data "aws_iam_policy_document" "parliament_mcp_secrets_manager" {
     actions = [
       "ssm:GetParameter",
       "ssm:GetParameters",
+      "ssm:GetParametersByPath"
     ]
     resources = [
-      "arn:aws:ssm:${var.region}:${data.aws_caller_identity.current.account_id}:parameter/${local.name}/env_secrets/*"
+      "arn:aws:ssm:*:${data.aws_caller_identity.current.account_id}:parameter/${local.name}/env_secrets/*"
     ]
   }
 

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -17,6 +17,13 @@ module "parliament_mcp_ingest_lambda" {
   permissions_boundary_name      = "infra/${local.name}-perms-boundary-app"
   # Only schedule in prod, disabled in dev
   schedule                       = terraform.workspace == "prod" ? "cron(0 5 ? * * *)" : null
+
+  environment_variables = {
+    APP_NAME = "${local.name}-parliament-mcp-ingest"
+    AWS_REGION = var.region
+    ENVIRONMENT = terraform.workspace
+    PROJECT_NAME = local.name
+  }
 }
 
 data "aws_iam_policy_document" "parliament_mcp_secrets_manager" {

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -5,7 +5,7 @@ module "parliament_mcp_ingest_lambda" {
   image_config = {
     working_directory : "",
   }
-  policies                       = [jsonencode(data.aws_iam_policy_document.parliament_mcp_secrets_manager.json)]
+  lambda_additional_policy_arns  = { for idx, arn in [aws_iam_policy.parliament_mcp_secrets_manager.arn] : idx => arn }
   package_type                   = "Image"
   function_name                  = "${local.name}-parliament-mcp-ingest"
   timeout                        = 900
@@ -59,6 +59,11 @@ data "aws_iam_policy_document" "parliament_mcp_secrets_manager" {
       data.terraform_remote_state.platform.outputs.kms_key_arn,
     ]
   }
+}
+
+resource "aws_iam_policy" "parliament_mcp_secrets_manager" {
+  name   = "${local.name}-secrets-ssm-access-policy"
+  policy = data.aws_iam_policy_document.parliament_mcp_secrets_manager.json
 }
 
 resource "aws_security_group" "parliament_mcp_security_group" {

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -29,6 +29,18 @@ data "aws_iam_policy_document" "parliament_mcp_secrets_manager" {
       "arn:aws:secretsmanager:${var.region}:${data.aws_caller_identity.current.account_id}:secret:i-dot-ai-${terraform.workspace}-parliament-mcp-environment-variables-*"
     ]
   }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey",
+      "kms:DescribeKey",
+    ]
+    resources = [
+      data.terraform_remote_state.platform.outputs.kms_key_arn,
+    ]
+  }
 }
 
 resource "aws_security_group" "parliament_mcp_security_group" {

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -39,6 +39,17 @@ data "aws_iam_policy_document" "parliament_mcp_secrets_manager" {
   statement {
     effect = "Allow"
     actions = [
+      "ssm:GetParameter",
+      "ssm:GetParameters",
+    ]
+    resources = [
+      "arn:aws:ssm:${var.region}:${data.aws_caller_identity.current.account_id}:parameter/${local.name}/env_secrets/*"
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
       "kms:Decrypt",
       "kms:GenerateDataKey",
       "kms:DescribeKey",


### PR DESCRIPTION
The lambda is failing to pull in secrets as env vars.

The tf module has no param to inject secrets, so best done via the boto ssm get parameter calls.