### PR TITLE
Support optional dates and add test case

### DIFF
--- a/parliament_mcp/mcp_server/qdrant_query_handler.py
+++ b/parliament_mcp/mcp_server/qdrant_query_handler.py
@@ -22,8 +22,8 @@ def build_date_range_filter(
     return FieldCondition(
         key=field,
         range=DatetimeRange(
-            gte=datetime.fromisoformat(date_from).date(),
-            lte=datetime.fromisoformat(date_to).date(),
+            gte=datetime.fromisoformat(date_from).date() if date_from else None,
+            lte=datetime.fromisoformat(date_to).date() if date_to else None,
         ),
     )
 

--- a/tests/mcp_server/test_handlers.py
+++ b/tests/mcp_server/test_handlers.py
@@ -120,3 +120,18 @@ async def test_search_hansard_contributions_with_filters(
 
     top_contribution_url = "https://hansard.parliament.uk/Commons/2025-06-24/debates/3E222FED-6C44-400C-8ABD-112BDCDAE98B/link#contribution-69057392-95C1-40B9-A415-6B4CCCFEE821"
     assert results[0]["contribution_url"] == top_contribution_url
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_search_debates_with_filters(qdrant_query_handler: QdrantQueryHandler):
+    """Test debates search with specific parameters."""
+    results = await qdrant_query_handler.search_debates(
+        query="G7 and NATO Summits",
+        date_from="2025-06-20",
+        max_results=5,
+    )
+    assert results is not None
+    assert len(results) <= 5  # Should respect max_results parameter
+    # May be 0 if no matching data in test set for this specific query and date
+    assert len(results) > 0


### PR DESCRIPTION
MCP server would previously fail if only one date filter was provided. Useful for queries like 'what happened since date X'