### PR TITLE
Add alb_name_override argument for parliament MCP to allow deployments

### DIFF
--- a/terraform/load_balancer.tf
+++ b/terraform/load_balancer.tf
@@ -9,7 +9,7 @@ module "load_balancer" {
   certificate_arn   = data.terraform_remote_state.universal.outputs.certificate_arn
   web_acl_arn       = module.waf.web_acl_arn
   env               = var.env
-
+  alb_name_override = "${var.env}-parliament-mcp-alb"
 }
 
 module "waf" {


### PR DESCRIPTION
Deployments are currently being blocked due to the name being truncated by our ECS module, which happens when an ALB name is > 32 characters. This commit adds a name override to reduce the size of the ALB name.

**Note:** this will recreate the ALB across all environments when it is deployed, likely causing a blip in connectivity. 