### PR TITLE
Fix for members id index

### DIFF
--- a/parliament_mcp/qdrant_helpers.py
+++ b/parliament_mcp/qdrant_helpers.py
@@ -250,14 +250,8 @@ async def create_collection_indicies(client: AsyncQdrantClient, settings: Parlia
         field_name="MemberId",
         field_schema=models.IntegerIndexParams(
             type=models.IntegerIndexType.INTEGER,
-        ),
-        wait=False,
-    )
-    await client.create_payload_index(
-        collection_name=settings.HANSARD_CONTRIBUTIONS_COLLECTION,
-        field_name="MemberId",
-        field_schema=models.KeywordIndexParams(
-            type=models.KeywordIndexType.KEYWORD,
+            lookup=True,
+            range=True,
         ),
         wait=False,
     )


### PR DESCRIPTION
I think due a bug in qdrant, we need to set `lookup=True` explicitly on integer indices so that they can be used in group by queries.