### PR TITLE
Add ability to query all ministers and filter by written question answering body

### DIFF
--- a/Dockerfile.mcp-server
+++ b/Dockerfile.mcp-server
@@ -1,9 +1,13 @@
 FROM public.ecr.aws/docker/library/python:3.12-slim
 
+# Accept version as build argument
+ARG VERSION="0.1.0+unknown"
+
 # Set environment variables
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
 ENV COLUMNS=200
+ENV APP_VERSION=$VERSION
 
 # Install system dependencies and uv
 RUN apt-get update && apt-get install -y \

--- a/parliament_mcp/__init__.py
+++ b/parliament_mcp/__init__.py
@@ -1,5 +1,17 @@
 """Parliament MCP - A Model Context Protocol server for UK Parliament data."""
 
+import os
+from importlib.metadata import PackageNotFoundError, version
+
 from parliament_mcp.cli import configure_logging
 
-__all__ = ["configure_logging"]
+# Try to get version from package metadata first
+try:
+    _package_version = version("parliament-mcp")
+except PackageNotFoundError:
+    _package_version = "unknown"
+
+# Read version from environment variable, fallback to package version
+__version__ = os.environ.get("APP_VERSION", _package_version)
+
+__all__ = ["__version__", "configure_logging"]

--- a/parliament_mcp/mcp_server/api.py
+++ b/parliament_mcp/mcp_server/api.py
@@ -314,6 +314,10 @@ async def search_parliamentary_questions(
     dateTo: str | None = Field(None, description="End date (YYYY-MM-DD)"),
     party: str | None = Field(None, description="Party"),
     member_id: int | None = Field(None, description="Member ID"),
+    answering_body_name: str | None = Field(
+        None,
+        description="Answering body name (e.g. 'Department for Transport, Cabinet Office, etc.)",
+    ),
 ) -> Any:
     """
     Search Parliamentary Written Questions (sometimes known as PQs)
@@ -326,6 +330,7 @@ async def search_parliamentary_questions(
     - Provide a query, date range, party and member name to search for written questions on a specific topic in a specific date range by a specific member of a specific party
     - Provide a member name to search for all written questions by a specific member for all time
     - Provide a member id to search for all written questions by a specific member for all time
+    - Provide an answering body name to search for all questions answered by a specific body or department such as 'Department for Transport' or 'Cabinet Office'
     """
     ctx = mcp_server.get_context()
     qdrant_query_handler: QdrantQueryHandler = ctx.request_context.lifespan_context["qdrant_query_handler"]
@@ -335,6 +340,7 @@ async def search_parliamentary_questions(
         dateTo=dateTo,
         party=party,
         member_id=member_id,
+        answering_body_name=answering_body_name,
     )
 
     if not result:

--- a/parliament_mcp/mcp_server/main.py
+++ b/parliament_mcp/mcp_server/main.py
@@ -4,6 +4,7 @@ import uvicorn
 from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 
+from parliament_mcp import __version__
 from parliament_mcp.mcp_server.api import mcp_server, settings
 
 
@@ -20,7 +21,13 @@ def create_app():
 
     @app.get("/healthcheck")
     async def health_check():
-        return JSONResponse(status_code=200, content={"status": "ok"})
+        return JSONResponse(
+            status_code=200,
+            content={
+                "status": "ok",
+                "version": __version__,
+            },
+        )
 
     app.mount(settings.MCP_ROOT_PATH, mcp_server.streamable_http_app())
 

--- a/parliament_mcp/mcp_server/qdrant_query_handler.py
+++ b/parliament_mcp/mcp_server/qdrant_query_handler.py
@@ -350,6 +350,7 @@ class QdrantQueryHandler:
         dateTo: str | None = None,  # noqa: N803
         party: str | None = None,
         member_id: int | None = None,
+        answering_body_name: str | None = None,
         min_score: float = 0,
         max_results: int = 100,
     ) -> list[dict]:
@@ -362,6 +363,7 @@ class QdrantQueryHandler:
             dateTo: End date in format 'YYYY-MM-DD' (optional)
             party: Filter by party (optional)
             member_id: Filter by member id (optional)
+            answering_body_name: Filter by answering body name (optional)
             min_score: Minimum relevance score (default 0)
             max_results: Maximum number of results to return (default 100)
         """
@@ -371,6 +373,11 @@ class QdrantQueryHandler:
             build_match_filter("askingMember.party", party),
             build_match_filter("askingMember.id", member_id),
         ]
+
+        if answering_body_name:
+            filter_conditions.append(
+                FieldCondition(key="answeringBodyName", match=models.MatchText(text=answering_body_name))
+            )
 
         query_filter = build_filters(filter_conditions)
 
@@ -443,6 +450,7 @@ class QdrantQueryHandler:
                     "answeringMember": payload.get("answeringMember"),
                     "dateTabled": parse_date(payload.get("dateTabled")),
                     "dateAnswered": parse_date(payload.get("dateAnswered")),
+                    "answeringBodyName": payload.get("answeringBodyName"),
                 }
             )
 

--- a/parliament_mcp/qdrant_helpers.py
+++ b/parliament_mcp/qdrant_helpers.py
@@ -56,7 +56,12 @@ async def create_collection_if_none(
                     "modifier": models.Modifier.IDF,
                 },
             },
-            quantization_config=models.ScalarQuantizationConfig(type="int8", always_ram=True),
+            quantization_config=models.ScalarQuantization(
+                scalar=models.ScalarQuantizationConfig(
+                    type=models.ScalarType.INT8,
+                    always_ram=True,
+                )
+            ),
         )
         logger.info("Created collection - %s", collection_name)
     else:
@@ -218,9 +223,16 @@ async def create_collection_indicies(client: AsyncQdrantClient, settings: Parlia
 
     await client.create_payload_index(
         collection_name=settings.PARLIAMENTARY_QUESTIONS_COLLECTION,
-        field_name="answeringBodyId",
-        field_schema=models.IntegerIndexParams(
-            type=models.IntegerIndexType.INTEGER,
+        field_name="answeringBodyName",
+        field_schema=models.TextIndexParams(
+            type="text",
+            tokenizer=models.TokenizerType.WORD,
+            min_token_len=2,
+            max_token_len=10,
+            lowercase=True,
+            phrase_matching=False,
+            stopwords="english",
+            stemmer=models.SnowballParams(type=models.Snowball.SNOWBALL, language=models.SnowballLanguage.ENGLISH),
         ),
         wait=False,
     )
@@ -274,8 +286,9 @@ async def create_collection_indicies(client: AsyncQdrantClient, settings: Parlia
             min_token_len=2,
             max_token_len=10,
             lowercase=True,
-            phrase_matching=True,
+            phrase_matching=False,
             stopwords="english",
+            stemmer=models.SnowballParams(type=models.Snowball.SNOWBALL, language=models.SnowballLanguage.ENGLISH),
         ),
         wait=False,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ skip = [
 
 [project]
 name = "parliament-mcp"
-version = "0.1.0"
+version = "0.2.0"
 authors = [{name = "i.AI", email = "i-dot-ai-enquiries@cabinetoffice.gov.uk"}]
 license = {text = "MIT"}
 description = "A library for working with UK Parliamentary data"

--- a/tests/mcp_server/test_agent.py
+++ b/tests/mcp_server/test_agent.py
@@ -59,3 +59,23 @@ async def test_we_can_find_relevant_contributions(test_mcp_agent: Agent):
 
     contribution_url = "https://hansard.parliament.uk/Commons/2025-06-24/debates/3E222FED-6C44-400C-8ABD-112BDCDAE98B/link#contribution-69057392-95C1-40B9-A415-6B4CCCFEE821"
     assert contribution_url in result.final_output, "Contribution URL not found in the final output"
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_find_junior_ministers(test_mcp_agent: Agent):
+    """
+    Test that the agent can use the MCP server to search the Members API.
+    """
+    result: RunResult = await Runner.run(
+        test_mcp_agent,
+        input="""
+        Find the junior ministers for the Department of Health and Social Care.
+        Provide the name of the junior ministers.""",
+    )
+    tool_calls: list[RunItem] = list(filter(lambda item: item.type == "tool_call_item", result.new_items))
+    assert any(tool_call.raw_item.name == "list_ministerial_roles" for tool_call in tool_calls), (
+        "No list_ministerial_roles tool call found"
+    )
+
+    assert "junior ministers" in result.final_output.lower(), "`junior ministers` not found in the final output"

--- a/tests/mcp_server/test_agent.py
+++ b/tests/mcp_server/test_agent.py
@@ -35,7 +35,7 @@ async def test_interaction_with_members_api(test_mcp_agent: Agent):
     """
     result: RunResult = await Runner.run(test_mcp_agent, input="Who is the current Chancellor")
     tool_calls: list[RunItem] = list(filter(lambda item: item.type == "tool_call_item", result.new_items))
-    assert any(tool_call.raw_item.name == "get_government_posts" for tool_call in tool_calls)
+    assert any(tool_call.raw_item.name == "list_ministerial_roles" for tool_call in tool_calls)
 
 
 @pytest.mark.asyncio

--- a/tests/mcp_server/test_handlers.py
+++ b/tests/mcp_server/test_handlers.py
@@ -66,7 +66,7 @@ async def test_search_hansard_contributions_with_member_id(
 @pytest.mark.integration
 async def test_search_debates(qdrant_query_handler: QdrantQueryHandler):
     """Test debates search with test data."""
-    results = await qdrant_query_handler.search_debates(
+    results = await qdrant_query_handler.search_debate_titles(
         date_from="2025-06-20",
         date_to="2025-06-25",
         house="Commons",
@@ -79,8 +79,9 @@ async def test_search_debates(qdrant_query_handler: QdrantQueryHandler):
 @pytest.mark.integration
 async def test_pmqs_are_on_wednesdays(qdrant_query_handler: QdrantQueryHandler):
     """Test that PMQs are on Wednesdays."""
-    results = await qdrant_query_handler.search_debates(
+    results = await qdrant_query_handler.search_debate_titles(
         # Not technically the title of the debate, but good to test with
+        # Should find https://hansard.parliament.uk/Commons/2025-06-25/debates/4777FB03-8AEC-422A-996F-A395AAD30963/Engagements
         query="Prime Minister's Questions",
         date_from="2025-01-01",
         date_to="2025-07-31",
@@ -126,8 +127,10 @@ async def test_search_hansard_contributions_with_filters(
 @pytest.mark.integration
 async def test_search_debates_with_filters(qdrant_query_handler: QdrantQueryHandler):
     """Test debates search with specific parameters."""
-    results = await qdrant_query_handler.search_debates(
-        query="G7 and NATO Summits",
+
+    # Should find https://hansard.parliament.uk/commons/2025-06-25/debates/600CC999-37EB-4B34-A324-806698158D78/Nuclear-CertifiedAircraftProcurement
+    results = await qdrant_query_handler.search_debate_titles(
+        query="Aircraft Procurement",
         date_from="2025-06-20",
         max_results=5,
     )
@@ -135,3 +138,18 @@ async def test_search_debates_with_filters(qdrant_query_handler: QdrantQueryHand
     assert len(results) <= 5  # Should respect max_results parameter
     # May be 0 if no matching data in test set for this specific query and date
     assert len(results) > 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_search_parliamentary_questions_with_answering_body_name(qdrant_query_handler: QdrantQueryHandler):
+    """Test Parliamentary Questions search with answering body name."""
+    # https://members-api.parliament.uk/index.html#operations-Reference-get_api_Reference_AnsweringBodies
+    results = await qdrant_query_handler.search_parliamentary_questions(
+        answering_body_name="Department for Transport",
+        max_results=10,
+    )
+    assert results is not None
+    assert len(results) > 0
+    for result in results:
+        assert "Department for Transport" in result["answeringBodyName"]

--- a/uv.lock
+++ b/uv.lock
@@ -1306,7 +1306,7 @@ wheels = [
 
 [[package]]
 name = "parliament-mcp"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
This PR does the following 

1. Return all ministers (secretaries, junior, or otherwise) in the `list_ministerial_roles`
2. Combined `get_government_posts` and `get_opposition_posts`
3. Fix some integration tests that were broken
4. Improve indexing on debate titles and add index for answering bodies in PQs
5. Add ability to query by answering body for PQs
6. Add version numbers to the docker build and the healthcheck endpoint. Useful for checking which version is running