### PR TITLE
Stateful MCP Server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ test_integration_cleanup:  ## Clean up files created by integration tests
 	rm -rf .cache .pytest_cache tests/.parliament-test-qdrant-data
 
 run_qdrant:
-	docker compose up -d qdrant --wait
+	docker compose up qdrant
 
 run_mcp_server:
 	uv run parliament-mcp serve

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,7 +6,7 @@ services:
       - "${QDRANT_PORT:-6333}:6333"
       - "6334:6334"
     volumes:
-      - qdrant_data:/qdrant/storage
+      - ./tests/.parliament-test-qdrant-data:/qdrant/storage:z
     networks:
       - parliament-mcp-network
     # Note: Qdrant container doesn't include curl, so we'll rely on port availability

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,7 +6,7 @@ services:
       - "${QDRANT_PORT:-6333}:6333"
       - "6334:6334"
     volumes:
-      - ./tests/.parliament-test-qdrant-data:/qdrant/storage:z
+      - qdrant_data:/qdrant/storage
     networks:
       - parliament-mcp-network
     # Note: Qdrant container doesn't include curl, so we'll rely on port availability

--- a/parliament_mcp/mcp_server/api.py
+++ b/parliament_mcp/mcp_server/api.py
@@ -30,7 +30,7 @@ async def mcp_lifespan(_server: FastMCP) -> AsyncGenerator[dict]:
         }
 
 
-mcp_server = FastMCP(name="Parliament MCP Server", lifespan=mcp_lifespan)
+mcp_server = FastMCP(name="Parliament MCP Server", stateless_http=False, lifespan=mcp_lifespan)
 
 # init Sentry if configured
 if settings.SENTRY_DSN and settings.ENVIRONMENT in ["dev", "preprod", "prod"] and settings.SENTRY_DSN != "placeholder":
@@ -301,7 +301,7 @@ async def search_parliamentary_questions(
     dateFrom: str | None = Field(None, description="Start date (YYYY-MM-DD)"),
     dateTo: str | None = Field(None, description="End date (YYYY-MM-DD)"),
     party: str | None = Field(None, description="Party"),
-    member_id: int | None = Field(None, description="Member ID"),
+    asking_member_id: int | None = Field(None, description="Member ID of the asking member"),
     answering_body_name: str | None = Field(
         None,
         description="Answering body name (e.g. 'Department for Transport, Cabinet Office, etc.)",
@@ -327,7 +327,7 @@ async def search_parliamentary_questions(
         dateFrom=dateFrom,
         dateTo=dateTo,
         party=party,
-        member_id=member_id,
+        asking_member_id=asking_member_id,
         answering_body_name=answering_body_name,
     )
 

--- a/parliament_mcp/mcp_server/qdrant_query_handler.py
+++ b/parliament_mcp/mcp_server/qdrant_query_handler.py
@@ -349,7 +349,7 @@ class QdrantQueryHandler:
         dateFrom: str | None = None,  # noqa: N803
         dateTo: str | None = None,  # noqa: N803
         party: str | None = None,
-        member_id: int | None = None,
+        asking_member_id: int | None = None,
         answering_body_name: str | None = None,
         min_score: float = 0,
         max_results: int = 100,
@@ -362,7 +362,7 @@ class QdrantQueryHandler:
             dateFrom: Start date in format 'YYYY-MM-DD' (optional)
             dateTo: End date in format 'YYYY-MM-DD' (optional)
             party: Filter by party (optional)
-            member_id: Filter by member id (optional)
+            asking_member_id: Filter by member id (optional)
             answering_body_name: Filter by answering body name (optional)
             min_score: Minimum relevance score (default 0)
             max_results: Maximum number of results to return (default 100)
@@ -371,7 +371,7 @@ class QdrantQueryHandler:
         filter_conditions = [
             build_date_range_filter(dateFrom, dateTo, "dateTabled"),
             build_match_filter("askingMember.party", party),
-            build_match_filter("askingMember.id", member_id),
+            build_match_filter("askingMember.id", asking_member_id),
         ]
 
         if answering_body_name:

--- a/parliament_mcp/mcp_server/utils.py
+++ b/parliament_mcp/mcp_server/utils.py
@@ -126,7 +126,6 @@ async def request_members_api(
     endpoint: str,
     params: dict[str, Any] | None = None,
     remove_null_values: bool = False,
-    return_string: bool = True,
 ) -> Any:
     """Make a request to the Parliament API and return JSON response"""
     url = f"{MEMBERS_API_BASE_URL}{endpoint}"
@@ -151,12 +150,7 @@ async def request_members_api(
         if remove_null_values:
             result = recursive_remove_null_values(result)
 
-        result = remap_values(result)
-
-        if return_string:
-            return json.dumps(result)
-        else:
-            return result
+        return remap_values(result)
     except Exception:
         logger.exception("Exception in request_members_api: %s, %s", url, params)
         raise
@@ -171,11 +165,11 @@ def clean_posts_list(posts_list: list[dict]) -> list:
             if field in post:
                 post.pop(field)
         for post_holder in post["postHolders"]:
-            for field in ["isPaid", "thumbnailUrl", "endDate"]:
+            for field in ["isPaid", "thumbnailUrl", "endDate", "layingMinisterName"]:
                 if field in post_holder:
                     post_holder.pop(field)
             # member fields
-            for field in ["latestHouseMembership", "latestParty", "nameFullTitle", "nameListAs"]:
+            for field in ["latestHouseMembership", "latestParty", "nameFullTitle", "nameListAs", "nameAddressAs"]:
                 if field in post_holder["member"]:
                     post_holder["member"].pop(field)
 

--- a/tests/mcp_server/test_benchmarks.py
+++ b/tests/mcp_server/test_benchmarks.py
@@ -1,0 +1,68 @@
+"""Benchmzzark tests for MCP server tools."""
+
+import logging
+import statistics
+import time
+
+import pytest
+from agents.mcp import MCPServerStreamableHttp
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_mcp_server_sequential_tool_benchmark(test_mcp_client: MCPServerStreamableHttp):
+    """Benchmark test that calls 5-6 tools in sequence through the actual MCP server."""
+
+    async def make_tool_calls():
+        await test_mcp_client.call_tool(
+            "search_constituency",
+            {
+                "searchText": "Manchester",
+            },
+        )
+
+        await test_mcp_client.call_tool(
+            "search_members",
+            {
+                "Name": "Keir Starmer",
+            },
+        )
+
+        await test_mcp_client.call_tool(
+            "search_parliamentary_questions",
+            {"query": "GP funding", "asking_member_id": 5239},
+        )
+
+        await test_mcp_client.call_tool(
+            "search_contributions",
+            {
+                "memberId": 4356,
+                "query": "NATO",
+            },
+        )
+
+        await test_mcp_client.call_tool(
+            "search_debate_titles",
+            {
+                "query": "NATO",
+            },
+        )
+
+    n = 10
+    times = []
+    for _ in range(n):
+        start_time = time.perf_counter()
+        await make_tool_calls()
+        end_time = time.perf_counter()
+        times.append(end_time - start_time)
+
+    average_time = statistics.mean(times)
+    std_dev = statistics.stdev(times)
+    logger.info("Average time taken: %s seconds", average_time)
+    logger.info("Standard deviation: %s seconds", std_dev)
+    logger.info("Min time taken: %s seconds", min(times))
+    logger.info("Max time taken: %s seconds", max(times))
+
+    assert average_time < 1.0, "Average time to complete 5 tool calls should be less than 1 second"

--- a/tests/mcp_server/test_handlers.py
+++ b/tests/mcp_server/test_handlers.py
@@ -1,17 +1,8 @@
 from datetime import UTC, datetime
 
 import pytest
-from qdrant_client import AsyncQdrantClient
 
-from parliament_mcp.embedding_helpers import get_openai_client
 from parliament_mcp.mcp_server.qdrant_query_handler import QdrantQueryHandler
-from parliament_mcp.settings import settings
-
-
-@pytest.fixture
-async def qdrant_query_handler(qdrant_test_client: AsyncQdrantClient):
-    openai_client = get_openai_client(settings)
-    return QdrantQueryHandler(qdrant_test_client, openai_client, settings)
 
 
 # mark async


### PR DESCRIPTION
The current MCP server is quite slow because it is stateful

This PR also fixes

1. Unnecessary string to json conversions
2. The leader of the opposition was not being returned as a department and therefore as an opposition post

Benchmarks:
- With `stateless_http=False`: 0.5-1 seconds
- With `stateless_http=True`: 3.5-4.5 seconds