### PR TITLE
return most recent debates in search_debate_titles

### DIFF
--- a/parliament_mcp/mcp_server/api.py
+++ b/parliament_mcp/mcp_server/api.py
@@ -107,15 +107,14 @@ async def search_debate_titles(
     Only returns the debate ID, title, and date, not the content of the debate.
     Useful for finding relevant debates, but must be used in conjunction with search_contributions to get the full text of the debate.
 
-    Either query or date range (or both) must be provided. House is optional.
-    If only date_from is provided, returns debates from that date onwards.
-    If only date_to is provided, returns debates up to and including that date.
+    Use date_from and date_to to search for debates in a specific date range.
+    Use query to search for debates with a keyword or phrase in the title.
 
-    Returns a list of debate details (ID, title, date) ranked by relevancy.
+    Returns a list of debate details (ID, title, date) in order the most recent first.
 
     Common use case for this function:
-    - Provide a query to search for debates on a specific topic for all time
-    - Provide the date for date_from and date_to to search for all debates on a specific date
+    - Provide a query to search for debates on a specific topic
+    - Provide the date for date_from and date_to to search for debates within a specific date range
     - Provide a query and date range to search for debates on a specific topic in a specific date range
 
     Args:

--- a/parliament_mcp/mcp_server/members.py
+++ b/parliament_mcp/mcp_server/members.py
@@ -52,7 +52,7 @@ async def get_election_results(
         raise ValueError(msg)
 
 
-# @log_tool_call
+@log_tool_call
 async def search_members(
     Name: str | None = Field(None, description="Member name"),
     PartyId: int | None = Field(None, description="Party ID"),

--- a/parliament_mcp/mcp_server/qdrant_query_handler.py
+++ b/parliament_mcp/mcp_server/qdrant_query_handler.py
@@ -123,7 +123,7 @@ class QdrantQueryHandler:
         date_from: str | None = None,
         date_to: str | None = None,
         house: str | None = None,
-        max_results: int = 100,
+        max_results: int = 50,
     ) -> list[dict]:
         """
         Search debate titles with optional filters.

--- a/parliament_mcp/qdrant_helpers.py
+++ b/parliament_mcp/qdrant_helpers.py
@@ -182,7 +182,7 @@ async def create_collection_indicies(client: AsyncQdrantClient, settings: Parlia
         field_schema=models.DatetimeIndexParams(
             type=models.DatetimeIndexType.DATETIME,
         ),
-        wait=False,
+        wait=True,
     )
 
     await client.create_payload_index(
@@ -191,7 +191,7 @@ async def create_collection_indicies(client: AsyncQdrantClient, settings: Parlia
         field_schema=models.DatetimeIndexParams(
             type=models.DatetimeIndexType.DATETIME,
         ),
-        wait=False,
+        wait=True,
     )
 
     await client.create_payload_index(
@@ -200,7 +200,7 @@ async def create_collection_indicies(client: AsyncQdrantClient, settings: Parlia
         field_schema=models.KeywordIndexParams(
             type=models.KeywordIndexType.KEYWORD,
         ),
-        wait=False,
+        wait=True,
     )
 
     await client.create_payload_index(
@@ -209,7 +209,7 @@ async def create_collection_indicies(client: AsyncQdrantClient, settings: Parlia
         field_schema=models.IntegerIndexParams(
             type=models.IntegerIndexType.INTEGER,
         ),
-        wait=False,
+        wait=True,
     )
 
     await client.create_payload_index(
@@ -218,7 +218,7 @@ async def create_collection_indicies(client: AsyncQdrantClient, settings: Parlia
         field_schema=models.KeywordIndexParams(
             type=models.KeywordIndexType.KEYWORD,
         ),
-        wait=False,
+        wait=True,
     )
 
     await client.create_payload_index(
@@ -234,7 +234,7 @@ async def create_collection_indicies(client: AsyncQdrantClient, settings: Parlia
             stopwords="english",
             stemmer=models.SnowballParams(type=models.Snowball.SNOWBALL, language=models.SnowballLanguage.ENGLISH),
         ),
-        wait=False,
+        wait=True,
     )
 
     await client.create_payload_index(
@@ -245,13 +245,6 @@ async def create_collection_indicies(client: AsyncQdrantClient, settings: Parlia
             lookup=True,
             range=True,
         ),
-        wait=False,
-    )
-
-    await client.create_payload_index(
-        collection_name=settings.PARLIAMENTARY_QUESTIONS_COLLECTION,
-        field_name="created_at",
-        field_schema=models.DatetimeIndexParams(type=models.DatetimeIndexType.DATETIME),
         wait=True,
     )
 
@@ -263,7 +256,7 @@ async def create_collection_indicies(client: AsyncQdrantClient, settings: Parlia
         field_schema=models.DatetimeIndexParams(
             type=models.DatetimeIndexType.DATETIME,
         ),
-        wait=False,
+        wait=True,
     )
 
     await client.create_payload_index(
@@ -272,7 +265,7 @@ async def create_collection_indicies(client: AsyncQdrantClient, settings: Parlia
         field_schema=models.KeywordIndexParams(
             type=models.KeywordIndexType.KEYWORD,
         ),
-        wait=False,
+        wait=True,
     )
 
     await client.create_payload_index(
@@ -283,7 +276,7 @@ async def create_collection_indicies(client: AsyncQdrantClient, settings: Parlia
             lookup=True,
             range=True,
         ),
-        wait=False,
+        wait=True,
     )
 
     await client.create_payload_index(
@@ -292,7 +285,7 @@ async def create_collection_indicies(client: AsyncQdrantClient, settings: Parlia
         field_schema=models.KeywordIndexParams(
             type=models.KeywordIndexType.KEYWORD,
         ),
-        wait=False,
+        wait=True,
     )
 
     await client.create_payload_index(
@@ -308,5 +301,5 @@ async def create_collection_indicies(client: AsyncQdrantClient, settings: Parlia
             stopwords="english",
             stemmer=models.SnowballParams(type=models.Snowball.SNOWBALL, language=models.SnowballLanguage.ENGLISH),
         ),
-        wait=False,
+        wait=True,
     )


### PR DESCRIPTION
This PR changes the implementation of search_debate_titles so that results are ordered by the most recent first.

This implementation isn't the prettiest since qdrant requires that you choose between group by and order by. You cannot do both