### PR TITLE
Fix MCP DNS rebinding protection for production hosts

### DIFF
--- a/parliament_mcp/mcp_server/api.py
+++ b/parliament_mcp/mcp_server/api.py
@@ -5,6 +5,7 @@ from typing import Any, Literal
 
 import sentry_sdk
 from mcp.server.fastmcp.server import FastMCP
+from mcp.server.transport_security import TransportSecuritySettings
 from pydantic import Field
 
 from parliament_mcp.mcp_server.members import register_members_tools
@@ -32,7 +33,15 @@ async def mcp_lifespan(_server: FastMCP) -> AsyncGenerator[dict]:
         }
 
 
-mcp_server = FastMCP(name="Parliament MCP Server", stateless_http=False, lifespan=mcp_lifespan)
+mcp_server = FastMCP(
+    name="Parliament MCP Server",
+    stateless_http=False,
+    lifespan=mcp_lifespan,
+    # Configure transport security with allowed hosts from settings
+    transport_security=TransportSecuritySettings(
+        allowed_hosts=[h.strip() for h in settings.MCP_ALLOWED_HOSTS.split(",") if h.strip()],
+    ),
+)
 
 register_committee_tools(mcp_server)
 register_members_tools(mcp_server)

--- a/parliament_mcp/settings.py
+++ b/parliament_mcp/settings.py
@@ -116,6 +116,10 @@ class ParliamentMCPSettings(BaseSettings):
     # The MCP server can be accessed at /{MCP_ROOT_PATH}/mcp
     MCP_ROOT_PATH: str = "/"
 
+    # Allowed hosts for MCP transport security (comma-separated)
+    # Used to prevent DNS rebinding attacks
+    MCP_ALLOWED_HOSTS: str = "localhost,127.0.0.1"
+
     # Rate limiting settings for parliament.uk API.
     HTTP_MAX_RATE_PER_SECOND: float = 10
 

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -44,6 +44,8 @@ module "backend" {
     "DOCKER_BUILDER_CONTAINER": "parliament-mcp",
     "AUTH_PROVIDER_PUBLIC_KEY": data.aws_ssm_parameter.auth_provider_public_key.value,
     # Qdrant connection is via QDRANT_URL and QDRANT_API_KEY from SSM (hosted Qdrant Cloud)
+    # MCP allowed hosts for DNS rebinding protection
+    "MCP_ALLOWED_HOSTS": "localhost,127.0.0.1,${local.host_backend}"
   }
 
   secrets = [


### PR DESCRIPTION
## Summary
- Fixes HTTP 421 errors from MCP library's DNS rebinding protection
- MCP v1.23.0+ auto-enables protection that rejects requests with unknown Host headers
- Parlex was getting `Invalid Host header` errors after parliament-mcp upgrade

## Changes
- `settings.py`: Add `MCP_ALLOWED_HOSTS` setting (default: `localhost,127.0.0.1`)
- `api.py`: Configure `TransportSecuritySettings` with allowed hosts
- `terraform/ecs.tf`: Set `MCP_ALLOWED_HOSTS` env var using `local.host_backend`

## Test plan
- [ ] Deploy to dev and verify Parlex can connect
- [ ] Check healthcheck returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)