### PR TITLE
feat: add Bills API tools (search_bills, get_bill_stages)

### DIFF
--- a/parliament_mcp/mcp_server/api.py
+++ b/parliament_mcp/mcp_server/api.py
@@ -14,6 +14,7 @@ from parliament_mcp.openai_helpers import get_openai_client
 from parliament_mcp.qdrant_helpers import get_async_qdrant_client
 from parliament_mcp.settings import settings
 
+from .bills import register_bills_tools
 from .committees import register_committee_tools
 from .utils import log_tool_call
 
@@ -43,6 +44,7 @@ mcp_server = FastMCP(
     ),
 )
 
+register_bills_tools(mcp_server)
 register_committee_tools(mcp_server)
 register_members_tools(mcp_server)
 

--- a/parliament_mcp/mcp_server/bills.py
+++ b/parliament_mcp/mcp_server/bills.py
@@ -4,7 +4,7 @@ from typing import Any, Literal
 from mcp.server.fastmcp.server import FastMCP
 from pydantic import Field
 
-from .utils import log_tool_call, request_bills_api, sanitize_params
+from .utils import log_tool_call, recursive_remove_null_values, request_bills_api, sanitize_params
 
 logger = logging.getLogger(__name__)
 
@@ -51,16 +51,18 @@ def clean_bill(bill: dict) -> dict:
     sponsors = bill.get("sponsors", [])
     if sponsors:
         result["sponsors"] = [
-            {
-                "name": s["member"]["name"],
-                "party": s["member"].get("party"),
-                "memberFrom": s["member"].get("memberFrom"),
-            }
+            recursive_remove_null_values(
+                {
+                    "name": s["member"]["name"],
+                    "party": s["member"].get("party"),
+                    "memberFrom": s["member"].get("memberFrom"),
+                }
+            )
             for s in sponsors
             if s.get("member")
         ]
 
-    return result
+    return recursive_remove_null_values(result)
 
 
 @log_tool_call

--- a/parliament_mcp/mcp_server/bills.py
+++ b/parliament_mcp/mcp_server/bills.py
@@ -1,0 +1,124 @@
+import logging
+from typing import Any, Literal
+
+from mcp.server.fastmcp.server import FastMCP
+from pydantic import Field
+
+from .utils import log_tool_call, request_bills_api, sanitize_params
+
+logger = logging.getLogger(__name__)
+
+BILL_URL = "https://bills.parliament.uk/bills"
+
+
+def clean_sitting(sitting: dict) -> str:
+    """Extract just the date from a stage sitting."""
+    return sitting["date"].split("T")[0]
+
+
+def clean_stage(stage: dict) -> dict:
+    """Extract the useful fields from a bill stage."""
+    result = {
+        "stage": stage["description"],
+        "abbreviation": stage["abbreviation"],
+        "house": stage["house"],
+    }
+    sittings = stage.get("stageSittings", [])
+    if sittings:
+        result["dates"] = [clean_sitting(s) for s in sittings]
+    return result
+
+
+def clean_bill(bill: dict) -> dict:
+    """Shape a bill response for LLM consumption — enough context, minimal noise."""
+    result = {
+        "billId": bill["billId"],
+        "title": bill["shortTitle"],
+        "url": f"{BILL_URL}/{bill['billId']}",
+        "currentHouse": bill.get("currentHouse"),
+        "originatingHouse": bill.get("originatingHouse"),
+        "isAct": bill.get("isAct", False),
+        "isDefeated": bill.get("isDefeated", False),
+    }
+
+    if bill.get("billWithdrawn"):
+        result["billWithdrawn"] = bill["billWithdrawn"]
+
+    current_stage = bill.get("currentStage")
+    if current_stage:
+        result["currentStage"] = clean_stage(current_stage)
+
+    sponsors = bill.get("sponsors", [])
+    if sponsors:
+        result["sponsors"] = [
+            {
+                "name": s["member"]["name"],
+                "party": s["member"].get("party"),
+                "memberFrom": s["member"].get("memberFrom"),
+            }
+            for s in sponsors
+            if s.get("member")
+        ]
+
+    return result
+
+
+@log_tool_call
+async def search_bills(
+    SearchTerm: str | None = Field(None, description="Search term to find bills by title"),
+    CurrentHouse: Literal["Commons", "Lords"] | None = Field(
+        None, description="Filter by which house the bill is currently in"
+    ),
+    OriginatingHouse: Literal["Commons", "Lords"] | None = Field(
+        None, description="Filter by which house the bill originated in"
+    ),
+    IsCurrentBill: bool | None = Field(
+        None,
+        description="Filter for current bills only (True) or former bills only (False). Default returns all.",
+    ),
+    ItemsPerPage: int = Field(20, description="Max results to return (default 20)"),
+) -> Any:
+    """Search for parliamentary bills by title or filter by house and status.
+
+    Returns bill title, current stage, scheduled sitting dates, and sponsors.
+    Use this to find out what stage a bill is at, when its next reading is, or who sponsored it.
+
+    Common use cases:
+    - Search by title to find a specific bill and its current stage/dates
+    - Filter by CurrentHouse to see what bills are before Commons or Lords
+    - Set IsCurrentBill=True to see only active bills in the current session
+    """
+    params = sanitize_params(**locals())
+
+    response = await request_bills_api("/api/v1/Bills", params=params)
+
+    items = response.get("items", [])
+    if not items:
+        return "No bills found"
+
+    return [clean_bill(bill) for bill in items]
+
+
+@log_tool_call
+async def get_bill_stages(
+    bill_id: int = Field(..., description="Bill ID (from search_bills results)"),
+) -> Any:
+    """Get the full legislative history of a bill — all stages with dates.
+
+    Returns every stage the bill has been through (1st reading, 2nd reading,
+    committee, report, 3rd reading, royal assent, etc.) with the dates of
+    each sitting. Stages are returned in legislative order.
+    """
+    response = await request_bills_api(f"/api/v1/Bills/{bill_id}/Stages")
+
+    items = response.get("items", [])
+    if not items:
+        return "No stages found for this bill"
+
+    items.sort(key=lambda s: s.get("sortOrder", 0))
+    return [clean_stage(stage) for stage in items]
+
+
+def register_bills_tools(mcp_server: FastMCP):
+    mcp_server.tool("search_bills")(search_bills)
+    mcp_server.tool("get_bill_stages")(get_bill_stages)

--- a/parliament_mcp/mcp_server/utils.py
+++ b/parliament_mcp/mcp_server/utils.py
@@ -13,6 +13,7 @@ logger = logging.getLogger(__name__)
 
 MEMBERS_API_BASE_URL = "https://members-api.parliament.uk"
 COMMITTEES_API_BASE_URL = "https://committees-api.parliament.uk"
+BILLS_API_BASE_URL = "https://bills-api.parliament.uk"
 
 
 def sanitize_params(**kwargs):
@@ -188,6 +189,30 @@ async def request_committees_api(
         return remap_values(result)
     except Exception:
         logger.exception("Exception in request_committees_api: %s, %s", url, params)
+        raise
+
+
+async def request_bills_api(
+    endpoint: str,
+    params: dict[str, Any] | None = None,
+) -> Any:
+    """Make a request to the Bills API and return JSON response"""
+    url = f"{BILLS_API_BASE_URL}{endpoint}"
+    logger.info("Requesting bills API: %s, %s", url, params)
+
+    try:
+        response = await cached_limited_get(
+            url,
+            headers={
+                "Accept": "application/json",
+                "User-Agent": "parliament-mcp",
+            },
+            params=params,
+        )
+        response.raise_for_status()
+        return recursive_remove_null_values(response.json())
+    except Exception:
+        logger.exception("Exception in request_bills_api: %s, %s", url, params)
         raise
 
 

--- a/parliament_mcp/mcp_server/utils.py
+++ b/parliament_mcp/mcp_server/utils.py
@@ -210,7 +210,8 @@ async def request_bills_api(
             params=params,
         )
         response.raise_for_status()
-        return recursive_remove_null_values(response.json())
+        result = recursive_remove_null_values(response.json())
+        return remap_values(result)
     except Exception:
         logger.exception("Exception in request_bills_api: %s, %s", url, params)
         raise

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,7 @@ known-first-party = ["parliament_mcp"]
 "*/tests/*" = ["S101", "S106", "PLR0913", "PLR0915", "PLR2004", "TD003"]
 # API files need to match external API parameter names
 "parliament_mcp/mcp_server/api.py" = ["E501"]  # Allow long lines in API files
+"parliament_mcp/mcp_server/bills.py" = ["N803"]  # Allow non-snake_case args to match Bills API parameter names
 "parliament_mcp/mcp_server/members.py" = ["N803", "A002", "E501", "N806"]  # Allow non-snake_case args, shadowing builtins, long lines, and non lowercase variables
 "parliament_mcp/mcp_server/handlers.py" = ["N803", "A001"]  # Allow non-snake_case args and shadowing builtins
 "parliament_mcp/mcp_server/main.py" = ["ARG001"]  # Allow unused args in FastAPI lifespan


### PR DESCRIPTION
## Summary

- Adds `search_bills` tool — search bills by title, house, and status; returns current stage with sitting dates and sponsors
- Adds `get_bill_stages` tool — get the full legislative history of a bill (all readings, committee stages, royal assent) with dates
- Adds `request_bills_api` utility in `utils.py` following the existing `request_members_api` pattern

## Motivation

A production user asked "when is the second reading for Preet Gill's Private Member's Bill?" and the model answered from training data (March 2025) instead of the correct date (17 April 2026). No bill-tracking tools existed, so the model had no way to look up live bill status.

## Response shaping

Responses are carefully trimmed to balance LLM context:

**Kept:** `billId`, `title`, URL, current house, stage description, sitting dates, sponsor name/party/constituency, `isAct`/`isDefeated` status

**Stripped:** Internal IDs (`stageId`, `sessionId`, `billStageId`), `lastUpdate`, `billTypeId`, session IDs, member photos/page URLs, `sortOrder`, promoters/agent/petitioning fields

## Example output

```json
// search_bills(SearchTerm="Public Body Ethnicity Data")
[{
  "billId": 3901,
  "title": "Public Body Ethnicity Data (Inclusion of Jewish and Sikh Categories) Bill",
  "url": "https://bills.parliament.uk/bills/3901",
  "currentHouse": "Commons",
  "currentStage": { "stage": "2nd reading", "abbreviation": "2R", "house": "Commons", "dates": ["2026-04-17"] }
}]
```

## Test plan

- [x] Manual end-to-end test: `search_bills` and `get_bill_stages` return correct data for known bills
- [x] Lint passes (`ruff check`)
- [ ] Verify tools are available via MCP client in dev


🤖 Generated with [Claude Code](https://claude.com/claude-code)