### PR TITLE
feat: REST API for MCP tools (+ preprod scaling)

### DIFF
--- a/parliament_mcp/mcp_server/api.py
+++ b/parliament_mcp/mcp_server/api.py
@@ -1,7 +1,7 @@
 import logging
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import sentry_sdk
 from mcp.server.fastmcp.server import FastMCP
@@ -9,28 +9,22 @@ from mcp.server.transport_security import TransportSecuritySettings
 from pydantic import Field
 
 from parliament_mcp.mcp_server.members import register_members_tools
-from parliament_mcp.mcp_server.qdrant_query_handler import QdrantQueryHandler
-from parliament_mcp.openai_helpers import get_openai_client
-from parliament_mcp.qdrant_helpers import get_async_qdrant_client
 from parliament_mcp.settings import settings
 
 from .committees import register_committee_tools
+from .resources import get_shared_resources
 from .utils import log_tool_call
+
+if TYPE_CHECKING:
+    from parliament_mcp.mcp_server.qdrant_query_handler import QdrantQueryHandler
 
 logger = logging.getLogger(__name__)
 
 
 @asynccontextmanager
 async def mcp_lifespan(_server: FastMCP) -> AsyncGenerator[dict]:
-    """Manage application lifecycle with type-safe context"""
-    # Initialize on startup
-
-    openai_client = get_openai_client(settings)
-    async with get_async_qdrant_client(settings) as qdrant_client:
-        yield {
-            "qdrant_query_handler": QdrantQueryHandler(qdrant_client, openai_client, settings),
-            "openai_client": openai_client,
-        }
+    """Yield the shared resources (initialized by the FastAPI lifespan)."""
+    yield get_shared_resources()
 
 
 mcp_server = FastMCP(

--- a/parliament_mcp/mcp_server/main.py
+++ b/parliament_mcp/mcp_server/main.py
@@ -9,6 +9,8 @@ from fastapi.responses import JSONResponse
 
 from parliament_mcp import __version__
 from parliament_mcp.mcp_server.api import mcp_server, settings
+from parliament_mcp.mcp_server.resources import initialize_shared_resources
+from parliament_mcp.mcp_server.rest_api import router as rest_router
 
 logger = logging.getLogger(__name__)
 
@@ -67,7 +69,7 @@ def create_app():
 
     @contextlib.asynccontextmanager
     async def lifespan(_app: FastAPI):
-        async with contextlib.AsyncExitStack() as stack:
+        async with initialize_shared_resources(), contextlib.AsyncExitStack() as stack:
             await stack.enter_async_context(mcp_server.session_manager.run())
             cleanup_task = asyncio.create_task(session_cleanup_task(mcp_server))
             try:
@@ -100,6 +102,7 @@ def create_app():
             },
         )
 
+    app.include_router(rest_router)
     app.mount(settings.MCP_ROOT_PATH, mcp_server.streamable_http_app())
 
     return app

--- a/parliament_mcp/mcp_server/resources.py
+++ b/parliament_mcp/mcp_server/resources.py
@@ -1,0 +1,35 @@
+"""Shared OpenAI + Qdrant resources used by both MCP tools and REST endpoints.
+
+The MCP lifespan and the FastAPI lifespan both read from the same singleton so
+that the QdrantQueryHandler is created once per app process and reused.
+"""
+
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+from typing import Any
+
+from parliament_mcp.openai_helpers import get_openai_client
+from parliament_mcp.qdrant_helpers import get_async_qdrant_client
+from parliament_mcp.settings import settings
+
+from .qdrant_query_handler import QdrantQueryHandler
+
+_shared: dict[str, Any] = {}
+
+
+@asynccontextmanager
+async def initialize_shared_resources() -> AsyncGenerator[dict[str, Any]]:
+    """Build the shared resources for the app lifetime."""
+    openai_client = get_openai_client(settings)
+    async with get_async_qdrant_client(settings) as qdrant_client:
+        _shared["qdrant_query_handler"] = QdrantQueryHandler(qdrant_client, openai_client, settings)
+        _shared["openai_client"] = openai_client
+        try:
+            yield _shared
+        finally:
+            _shared.clear()
+
+
+def get_shared_resources() -> dict[str, Any]:
+    """Return the shared-resources dict (empty before the lifespan runs)."""
+    return _shared

--- a/parliament_mcp/mcp_server/rest_api.py
+++ b/parliament_mcp/mcp_server/rest_api.py
@@ -1,0 +1,47 @@
+"""REST API that exposes every MCP tool as `POST /api/v1/tools/{name}`.
+
+Lets clients hit tools without the MCP session/JSON-RPC handshake — useful for
+curl, scripts, and anything that doesn't speak MCP.
+"""
+
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
+from mcp.server.lowlevel.server import request_ctx
+from mcp.shared.context import RequestContext
+
+from .api import mcp_server
+from .resources import get_shared_resources
+
+router = APIRouter(prefix="/api/v1", tags=["rest"])
+
+
+@router.get("/tools")
+async def list_tools() -> list[dict[str, Any]]:
+    """List every available tool with its name, description, and JSON input schema."""
+    tools = await mcp_server.list_tools()
+    return [{"name": t.name, "description": t.description, "inputSchema": t.inputSchema} for t in tools]
+
+
+@router.post("/tools/{tool_name}")
+async def call_tool(tool_name: str, arguments: dict[str, Any] | None = None) -> Any:
+    """Invoke an MCP tool. POST a JSON object of the tool's named arguments."""
+    tool = mcp_server._tool_manager.get_tool(tool_name)  # noqa: SLF001
+    if tool is None:
+        raise HTTPException(status_code=404, detail=f"Unknown tool: {tool_name}")
+
+    # Tool bodies call mcp_server.get_context() to grab the shared QdrantQueryHandler;
+    # outside an MCP session we set request_ctx ourselves with the shared resources.
+    stub = RequestContext(
+        request_id=f"rest-{tool_name}",
+        meta=None,
+        session=None,  # tools in this codebase don't touch the session
+        lifespan_context=get_shared_resources(),
+    )
+    token = request_ctx.set(stub)
+    try:
+        return await tool.run(arguments or {}, context=mcp_server.get_context(), convert_result=False)
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    finally:
+        request_ctx.reset(token)

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -28,8 +28,9 @@ module "backend" {
   permissions_boundary_name    = "infra/i-dot-ai-${var.env}-parliament-mcp-perms-boundary-app"
 
   # Resource allocation - increased from defaults (256/512) for embedding model overhead
-  memory = 2048
-  cpu    = 512
+  # Preprod gets double allocation
+  memory = var.env == "preprod" ? 4096 : 2048
+  cpu    = var.env == "preprod" ? 1024 : 512
 
   create_networking = true
   create_listener   = true


### PR DESCRIPTION
## Summary

- **REST API**: adds `GET /api/v1/tools` and `POST /api/v1/tools/{name}` so non-MCP clients (curl, scripts, anything that doesn't speak JSON-RPC) can call tools without the MCP `initialize` handshake. The preprod ALB has been showing intermittent 4xx noise from clients trying to POST to `/mcp` directly — this gives them a sane way in.
- **Resource sharing**: lifts the OpenAI client + QdrantQueryHandler out of the per-MCP-session lifespan into a process-wide singleton (`resources.py`) so both REST and MCP share one connection pool.
- **Preprod scaling** (cherry-picked from #47): doubles preprod ECS to 4096 MB / 1024 CPU; dev and prod stay at 2048/512.

## How the REST adapter works

The router doesn't reimplement any tool logic — it grabs the tool from FastMCP's tool manager, sets the `request_ctx` ContextVar with the shared lifespan resources, and calls `tool.run(args, context=ctx, convert_result=False)`. Existing tool function bodies that read from `mcp_server.get_context()` keep working unchanged. Validation, defaults, and JSON schemas all come from FastMCP's existing Pydantic argument models.

## Test plan

- [x] `GET /healthcheck` still works
- [x] `GET /api/v1/tools` lists all 13 (or 15 with bills) tools with name, description, and inputSchema
- [x] `POST /api/v1/tools/search_bills` returns real bill data (no MCP context required path)
- [x] `POST /api/v1/tools/search_debate_titles` returns real Qdrant-backed results (shared-context path)
- [x] Unknown tool name returns 404
- [x] Invalid argument types return 400 with the underlying Pydantic validation message
- [x] Existing MCP `/mcp` JSON-RPC endpoint still initializes and serves tools
- [ ] Smoke-test in preprod after deploy