### PR TITLE
fix: throttle Azure OpenAI embedding calls and back off on rate limits

### DIFF
--- a/parliament_mcp/openai_helpers.py
+++ b/parliament_mcp/openai_helpers.py
@@ -1,13 +1,46 @@
+import asyncio
 import logging
+import os
 from itertools import batched
 
 import httpx
+import openai
+from aiolimiter import AsyncLimiter
 from openai import AsyncAzureOpenAI
-from tenacity import retry, stop_after_attempt
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_random_exponential,
+)
 
 from parliament_mcp.settings import ParliamentMCPSettings
 
 logger = logging.getLogger(__name__)
+
+
+def _env_float(name: str, default: float) -> float:
+    try:
+        return float(os.environ.get(name, default))
+    except (TypeError, ValueError):
+        return default
+
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        return int(os.environ.get(name, default))
+    except (TypeError, ValueError):
+        return default
+
+
+# Throttles for Azure OpenAI embedding calls. Raise the env vars when on
+# a larger quota. TPM, not RPM, is usually the binding constraint.
+_EMBED_RATE_PER_SECOND = _env_float("OPENAI_EMBED_RATE_PER_SECOND", 1.5)
+_EMBED_MAX_CONCURRENCY = _env_int("OPENAI_EMBED_MAX_CONCURRENCY", 2)
+_EMBED_DEFAULT_BATCH_SIZE = _env_int("OPENAI_EMBED_BATCH_SIZE", 32)
+
+_embed_limiter = AsyncLimiter(max_rate=_EMBED_RATE_PER_SECOND, time_period=1.0)
+_embed_semaphore = asyncio.Semaphore(_EMBED_MAX_CONCURRENCY)
 
 
 def get_openai_client(settings: ParliamentMCPSettings) -> AsyncAzureOpenAI:
@@ -16,7 +49,10 @@ def get_openai_client(settings: ParliamentMCPSettings) -> AsyncAzureOpenAI:
         api_key=settings.AZURE_OPENAI_API_KEY,
         api_version=settings.AZURE_OPENAI_API_VERSION,
         azure_endpoint=settings.AZURE_OPENAI_ENDPOINT,
-        http_client=httpx.AsyncClient(timeout=30.0),
+        # The SDK honours Retry-After on 429s; let it ride out short windows
+        # before tenacity takes over for longer waits.
+        max_retries=6,
+        http_client=httpx.AsyncClient(timeout=60.0),
     )
 
 
@@ -27,21 +63,27 @@ async def embed_single(
     dimensions: int = 1024,
 ) -> list[float]:
     """Generate a single embedding for a text using Azure OpenAI."""
-    response = await client.embeddings.create(
-        input=text,
-        model=model,
-        dimensions=dimensions,
-    )
+    async with _embed_semaphore, _embed_limiter:
+        response = await client.embeddings.create(
+            input=text,
+            model=model,
+            dimensions=dimensions,
+        )
     return response.data[0].embedding
 
 
-@retry(stop=stop_after_attempt(3))
+@retry(
+    retry=retry_if_exception_type((openai.RateLimitError, openai.APITimeoutError, openai.APIConnectionError)),
+    wait=wait_random_exponential(min=2, max=60),
+    stop=stop_after_attempt(8),
+    reraise=True,
+)
 async def embed_batch(
     client: AsyncAzureOpenAI,
     texts: list[str],
     model: str,
     dimensions: int = 1024,
-    batch_size: int = 100,
+    batch_size: int = _EMBED_DEFAULT_BATCH_SIZE,
 ) -> list[list[float]]:
     """Generate embeddings for a list of texts using Azure OpenAI.
 
@@ -50,7 +92,7 @@ async def embed_batch(
         texts: List of texts to embed
         model: Deployment name for the embedding model
         dimensions: Number of dimensions for the embeddings (default 1024)
-        batch_size: Number of texts to process in each API call
+        batch_size: Number of texts per API call (default tuned for S0 tier)
 
     Returns:
         List of embedding vectors
@@ -59,15 +101,20 @@ async def embed_batch(
 
     for i, batch in enumerate(batched(texts, batch_size)):
         try:
-            response = await client.embeddings.create(
-                input=batch,
-                model=model,
-                dimensions=dimensions,
-            )
+            async with _embed_semaphore, _embed_limiter:
+                response = await client.embeddings.create(
+                    input=batch,
+                    model=model,
+                    dimensions=dimensions,
+                )
 
             batch_embeddings = [item.embedding for item in response.data]
             all_embeddings.extend(batch_embeddings)
 
+        except openai.RateLimitError:
+            # Let tenacity retry the whole batch with backoff.
+            logger.warning("Azure OpenAI rate limit hit on batch %d; backing off", i // batch_size + 1)
+            raise
         except Exception:
             logger.exception("Error generating embeddings for batch %d", i // batch_size + 1)
             raise

--- a/parliament_mcp/qdrant_data_loaders.py
+++ b/parliament_mcp/qdrant_data_loaders.py
@@ -234,12 +234,15 @@ class QdrantHansardLoader(QdrantDataLoader):
         from_date: str = "2020-01-01",
         to_date: str = "2020-02-10",
     ) -> None:
-        """Load all contribution types concurrently."""
+        """Load all contribution types sequentially.
+
+        Sequential rather than concurrent to keep total in-flight embedding
+        calls bounded; the per-type loader still parallelises pages internally.
+        """
         contribution_types = ["Spoken", "Written", "Corrections", "Petitions"]
         with self.progress_context():
-            async with asyncio.TaskGroup() as tg:
-                for contrib_type in contribution_types:
-                    tg.create_task(self.load_contributions_by_type(contrib_type, from_date, to_date))
+            for contrib_type in contribution_types:
+                await self.load_contributions_by_type(contrib_type, from_date, to_date)
 
     async def load_contributions_by_type(
         self,


### PR DESCRIPTION
`make load-data hansard` reliably 429s on the default Azure S0 tier. `load_all_contributions` fans out 4 contribution types in parallel x N pages each, `batch_size=100` puts ~30k tokens per call (well over 350k TPM in bursts), and `@retry(stop_after_attempt(3))` retries instantly with no backoff and ignores `Retry-After`.

Patch:
- Throttle every `embeddings.create` with an `aiolimiter` + semaphore. Tune via `OPENAI_EMBED_RATE_PER_SECOND` / `OPENAI_EMBED_MAX_CONCURRENCY` / `OPENAI_EMBED_BATCH_SIZE`. Defaults sized for S0; raise on larger quotas.
- Tenacity now uses `wait_random_exponential(2, 60)`, retries only on `RateLimitError` / `APITimeoutError` / `APIConnectionError`, up to 8 attempts.
- `max_retries=6` on the Azure client so the SDK honours `Retry-After` first.
- Default `batch_size` 100 to 32.
- `load_all_contributions` runs types sequentially; pages still parallelise within each type.

No new deps. 90-day Hansard load completes on S0 with these defaults.