### PR TITLE
fix: surface MCP tool failures instead of masking them as success

### DIFF
--- a/parliament_mcp/mcp_server/committees.py
+++ b/parliament_mcp/mcp_server/committees.py
@@ -11,7 +11,7 @@ from mcp.server.fastmcp.server import FastMCP
 
 from parliament_mcp.qdrant_data_loaders import cached_limited_get
 
-from .utils import COMMITTEES_API_BASE_URL, log_tool_call, request_committees_api
+from .utils import COMMITTEES_API_BASE_URL, gather_sections, log_tool_call, request_committees_api
 
 logger = logging.getLogger(__name__)
 
@@ -230,13 +230,15 @@ async def list_all_committees(
 
 async def get_basic_committee_info(committee_id: int):
     response = await request_committees_api(f"/api/Committees/{committee_id}")
+    # request_committees_api strips null fields, so optional ones may be absent.
+    category = response.get("category") or {}
     return {
         "id": response["id"],
         "name": response["name"],
-        "purpose": response["purpose"],
-        "category": response["category"]["name"],
-        "house": response["house"],
-        "subCommittees": [clean_committee_item(sub_committee) for sub_committee in response["subCommittees"]],
+        "purpose": response.get("purpose"),
+        "category": category.get("name"),
+        "house": response.get("house"),
+        "subCommittees": [clean_committee_item(sub_committee) for sub_committee in response.get("subCommittees", [])],
     }
 
 
@@ -299,29 +301,21 @@ async def get_committee_details(
         - committee_business: List of business/inquiries (if requested)
         - upcoming_events: List of upcoming events (if requested)
     """
-    tasks = {}
-    async with asyncio.TaskGroup() as tg:
-        # Always include basic info
-        tasks["basic_committee_info"] = tg.create_task(get_basic_committee_info(committee_id))
-        # Conditionally include other sections
-        if include_members:
-            tasks["members"] = tg.create_task(get_committee_members(committee_id))
-        if include_publications:
-            tasks["publications"] = tg.create_task(get_committee_publications(committee_id))
-        if include_oral_evidence:
-            tasks["oral_evidence"] = tg.create_task(get_committee_oral_evidence(committee_id))
-        if include_written_evidence:
-            tasks["written_evidence"] = tg.create_task(get_committee_written_evidence(committee_id))
-        if include_business:
-            tasks["committee_business"] = tg.create_task(get_committee_business(committee_id))
-        if include_upcoming_events:
-            tasks["upcoming_events"] = tg.create_task(get_committee_events(committee_id, upcoming_only=True))
+    sections = {"basic_committee_info": get_basic_committee_info(committee_id)}
+    if include_members:
+        sections["members"] = get_committee_members(committee_id)
+    if include_publications:
+        sections["publications"] = get_committee_publications(committee_id)
+    if include_oral_evidence:
+        sections["oral_evidence"] = get_committee_oral_evidence(committee_id)
+    if include_written_evidence:
+        sections["written_evidence"] = get_committee_written_evidence(committee_id)
+    if include_business:
+        sections["committee_business"] = get_committee_business(committee_id)
+    if include_upcoming_events:
+        sections["upcoming_events"] = get_committee_events(committee_id, upcoming_only=True)
 
-    # Build result with only requested sections
-    result = {}
-    for key, task in tasks.items():
-        result[key] = task.result()
-    return result
+    return await gather_sections(sections)
 
 
 @log_tool_call

--- a/parliament_mcp/mcp_server/members.py
+++ b/parliament_mcp/mcp_server/members.py
@@ -6,7 +6,15 @@ from typing import Any, Literal
 from mcp.server.fastmcp.server import FastMCP
 from pydantic import Field
 
-from .utils import clean_posts_list, log_tool_call, request_committees_api, request_members_api, sanitize_params
+from .utils import (
+    clean_posts_list,
+    extract_party_info,
+    gather_sections,
+    log_tool_call,
+    request_committees_api,
+    request_members_api,
+    sanitize_params,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -83,20 +91,21 @@ async def search_members(
         - latestParty: Latest party of the member
     """
     params = sanitize_params(**locals())
-    response = await request_members_api("/api/Members/Search", params)
+    members = await request_members_api("/api/Members/Search", params)
 
-    tasks = []
-    async with asyncio.TaskGroup() as tg:
-        for member in response:
-            tasks.append((member, tg.create_task(request_members_api(f"/api/Members/{member['id']}/Synopsis"))))
+    # Synopsis is decorative enrichment, so a failed one shouldn't sink the search.
+    synopses = await asyncio.gather(
+        *(request_members_api(f"/api/Members/{member['id']}/Synopsis") for member in members),
+        return_exceptions=True,
+    )
+    for member, synopsis in zip(members, synopses, strict=True):
+        if isinstance(synopsis, BaseException):
+            logger.warning("Synopsis for member %s failed: %s", member["id"], synopsis)
+            member["synopsis"] = ""
+        else:
+            member["synopsis"] = remove_tags(synopsis)
 
-    results = []
-    for member, task in tasks:
-        synopsis = task.result()
-        member["synopsis"] = remove_tags(synopsis)
-        results.append(member)
-
-    return results
+    return members
 
 
 @log_tool_call
@@ -130,46 +139,30 @@ async def get_detailed_member_information(
         include_voting_record: Whether to include member voting record
     """
 
-    tasks = {}
-    async with asyncio.TaskGroup() as tg:
-        tasks["member"] = tg.create_task(request_members_api(f"/api/Members/{member_id}"))
-        if include_synopsis:
-            tasks["synopsis"] = tg.create_task(request_members_api(f"/api/Members/{member_id}/Synopsis"))
-        if include_biography:
-            tasks["biography"] = tg.create_task(request_members_api(f"/api/Members/{member_id}/Biography"))
-        if include_contact:
-            tasks["contact"] = tg.create_task(
-                request_members_api(
-                    f"/api/Members/{member_id}/Contact",
-                    remove_null_values=True,
-                )
-            )
-        if include_registered_interests:
-            tasks["registered_interests"] = tg.create_task(
-                request_members_api(f"/api/Members/{member_id}/RegisteredInterests")
-            )
+    # The member record anchors the result (and provides the house for the voting
+    # lookup), so fetch it up front and let a genuine failure surface.
+    member = await request_members_api(f"/api/Members/{member_id}")
 
-        if include_committee_membership:
+    async def get_member_committees():
+        result = await request_committees_api("/api/Members", params={"Members": [member_id]})
+        return result[0]["committees"]
 
-            async def get_member_committees():
-                result = await request_committees_api("/api/Members", params={"Members": [member_id]})
-                return result[0]["committees"]
-
-            tasks["committee_membership"] = tg.create_task(get_member_committees())
-
+    sections = {}
+    if include_synopsis:
+        sections["synopsis"] = request_members_api(f"/api/Members/{member_id}/Synopsis")
+    if include_biography:
+        sections["biography"] = request_members_api(f"/api/Members/{member_id}/Biography")
+    if include_contact:
+        sections["contact"] = request_members_api(f"/api/Members/{member_id}/Contact", remove_null_values=True)
+    if include_registered_interests:
+        sections["registered_interests"] = request_members_api(f"/api/Members/{member_id}/RegisteredInterests")
+    if include_committee_membership:
+        sections["committee_membership"] = get_member_committees()
     if include_voting_record:
-        async with asyncio.TaskGroup() as tg:
-            member_house = tasks["member"].result()["latestHouseMembership"]["house"]
-            tasks["voting"] = tg.create_task(
-                request_members_api(f"/api/Members/{member_id}/Voting", params={"house": member_house})
-            )
+        member_house = member["latestHouseMembership"]["house"]
+        sections["voting"] = request_members_api(f"/api/Members/{member_id}/Voting", params={"house": member_house})
 
-    # Build result dictionary, handling any exceptions
-    result = {}
-    for key, task in tasks.items():
-        result[key] = task.result()
-
-    return result
+    return {"member": member, **await gather_sections(sections)}
 
 
 @log_tool_call
@@ -199,33 +192,33 @@ async def list_ministerial_roles(
 
     if include_all_minsiters:
         # Junior ministers are included when querying by departmentId
-        posts = []
         departments = await get_departments()
+        department_posts_list = await asyncio.gather(
+            *(
+                request_members_api(f"/api/Posts/{post_type}", params={"departmentId": department["id"]})
+                for department in departments
+            ),
+            return_exceptions=True,
+        )
 
-        tasks = []
-        async with asyncio.TaskGroup() as tg:
-            for department in departments:
-                tasks.append(
-                    (
-                        tg.create_task(
-                            request_members_api(f"/api/Posts/{post_type}", params={"departmentId": department["id"]})
-                        ),
-                        department,
-                    )
-                )
-
-        for task, department in tasks:
-            if department_posts := task.result():
-                party_info = department_posts[0]["postHolders"][0]["member"]["latestParty"]
-                department_posts = clean_posts_list(department_posts)
+        posts = []
+        for department, department_posts in zip(departments, department_posts_list, strict=True):
+            if isinstance(department_posts, BaseException):
+                logger.warning("Posts for department '%s' failed: %s", department["name"], department_posts)
+                continue
+            if department_posts:
+                party_info = party_info or extract_party_info(department_posts)
                 posts.append(
-                    {"department": department["name"], "department_id": department["id"], "posts": department_posts}
+                    {
+                        "department": department["name"],
+                        "department_id": department["id"],
+                        "posts": clean_posts_list(department_posts),
+                    }
                 )
     else:
         posts = await request_members_api(f"/api/Posts/{post_type}")
 
-        if posts:
-            party_info = posts[0]["postHolders"][0]["member"]["latestParty"]
+        party_info = extract_party_info(posts)
 
         posts = clean_posts_list(posts)
 
@@ -237,6 +230,8 @@ async def list_ministerial_roles(
 async def get_departments() -> Any:
     """Get departments"""
     results = await request_members_api("/api/Reference/Departments")
+    # Drop malformed entries so downstream department["id"] lookups stay safe.
+    results = [department for department in results if isinstance(department, dict) and "id" in department]
     # Leader of HM Official Opposition is a special case not returned by the departments API
     results.append({"id": 107, "name": "Leader of HM Official Opposition"})
     return results

--- a/parliament_mcp/mcp_server/utils.py
+++ b/parliament_mcp/mcp_server/utils.py
@@ -1,8 +1,9 @@
+import asyncio
 import functools
 import json
 import logging
 import time
-import traceback
+from collections.abc import Awaitable
 from typing import Any
 
 from pydantic.fields import FieldInfo
@@ -61,7 +62,7 @@ def log_tool_call(func):
                 str_kwargs,
                 execution_time,
             )
-            return f"Error in tool call `{func.__name__}`: {traceback.format_exc()}"
+            raise
         else:
             return result
 
@@ -197,15 +198,39 @@ def clean_posts_list(posts_list: list[dict]) -> list:
     """
     for post in posts_list:
         for field in ["type", "createdWhen", "order", "id", "governmentDepartments"]:
-            if field in post:
-                post.pop(field)
-        for post_holder in post["postHolders"]:
+            post.pop(field, None)
+        for post_holder in post.get("postHolders", []):
             for field in ["isPaid", "thumbnailUrl", "endDate", "layingMinisterName"]:
-                if field in post_holder:
-                    post_holder.pop(field)
-            # member fields
-            for field in ["latestHouseMembership", "latestParty", "nameFullTitle", "nameListAs", "nameAddressAs"]:
-                if field in post_holder["member"]:
-                    post_holder["member"].pop(field)
+                post_holder.pop(field, None)
+            member = post_holder.get("member")
+            if member:
+                for field in ["latestHouseMembership", "latestParty", "nameFullTitle", "nameListAs", "nameAddressAs"]:
+                    member.pop(field, None)
 
     return posts_list
+
+
+def extract_party_info(posts_list: list[dict]) -> dict | None:
+    """Return the ``latestParty`` of the first post holder that has one, or None."""
+    for post in posts_list:
+        for post_holder in post.get("postHolders", []):
+            party = (post_holder.get("member") or {}).get("latestParty")
+            if party is not None:
+                return party
+    return None
+
+
+async def gather_sections(sections: dict[str, Awaitable]) -> dict[str, Any]:
+    """Run named awaitables concurrently, returning only the ones that succeed.
+
+    A failed section is logged and dropped rather than sinking the whole result,
+    so one flaky upstream endpoint can't take out an entire tool call.
+    """
+    results = await asyncio.gather(*sections.values(), return_exceptions=True)
+    output = {}
+    for name, result in zip(sections, results, strict=True):
+        if isinstance(result, BaseException):
+            logger.warning("Section '%s' failed: %s", name, result)
+        else:
+            output[name] = result
+    return output

--- a/tests/mcp_server/test_api.py
+++ b/tests/mcp_server/test_api.py
@@ -43,6 +43,8 @@ async def test_list_all_committees(test_mcp_client: MCPServerStreamableHttp):
         (760, {"name": "City of London (Markets) Bill"}),
         # Commons select committee
         (327, {"name": "Public Administration and Constitutional Affairs Committee"}),
+        # Committee with a null `purpose` (must not KeyError)
+        (97, {"name": "Intelligence and Security Committee of Parliament"}),
     ],
 )
 async def test_get_committee_details(test_mcp_client: MCPServerStreamableHttp, committee_id: int, expected: dict):

--- a/tests/mcp_server/test_utils.py
+++ b/tests/mcp_server/test_utils.py
@@ -1,0 +1,38 @@
+import pytest
+
+from parliament_mcp.mcp_server.utils import extract_party_info, gather_sections
+
+
+async def _ok(value):
+    return value
+
+
+async def _boom():
+    raise RuntimeError
+
+
+@pytest.mark.asyncio
+async def test_gather_sections_keeps_successes_and_drops_failures():
+    result = await gather_sections({"a": _ok(1), "bad": _boom(), "b": _ok(2)})
+    assert result == {"a": 1, "b": 2}
+
+
+@pytest.mark.asyncio
+async def test_gather_sections_keeps_falsy_results():
+    # An empty section is a real result, not a failure, so it must be kept.
+    result = await gather_sections({"empty": _ok([]), "bad": _boom()})
+    assert result == {"empty": []}
+
+
+def test_extract_party_info_skips_vacant_and_partyless_holders():
+    posts = [
+        {"postHolders": []},  # vacant post
+        {"postHolders": [{"member": {}}]},  # holder without a party
+        {"postHolders": [{"member": {"latestParty": {"name": "Labour"}}}]},
+    ]
+    assert extract_party_info(posts) == {"name": "Labour"}
+
+
+def test_extract_party_info_returns_none_when_no_party_present():
+    assert extract_party_info([{"postHolders": [{}]}]) is None
+    assert extract_party_info([]) is None


### PR DESCRIPTION
## Problem

`log_tool_call` caught every exception and **returned the traceback as the tool's value**. FastMCP serialises a returned string as a normal `isError: false` result — so a failing tool looked like a *successful* call whose content happened to be a Python traceback, which was then returned to the caller (and any LLM consuming the tool) as data.

Several tools could hit this, all invisibly:

- `get_committee_details` — `KeyError: 'purpose'` for committees with a null `purpose` (e.g. committee 97), and an upstream 5xx from any single section sank the whole call.
- `list_ministerial_roles` / `search_members` / `get_detailed_member_information` — a single failed sub-request in the `asyncio.TaskGroup` fan-out failed the entire tool.
- `get_departments` — a malformed (non-dict) entry caused a `TypeError` on `department["id"]`.

## Changes

- **`log_tool_call` re-raises** instead of returning the traceback, so failures become proper `isError: true` tool errors. The full traceback still goes to logs via `logger.exception`; the session is unaffected (the MCP lowlevel server converts the exception to a clean error result).
- **`get_basic_committee_info`** uses `.get()` for `purpose`/`category`/`house`/`subCommittees` — `request_committees_api` strips null fields, so optional ones can be absent.
- **`get_departments`** drops malformed non-dict entries so the per-department fan-out can't `TypeError` on `department["id"]`.
- **Replaced all-or-nothing `asyncio.TaskGroup` with a `gather_sections()` helper** in the fan-out tools — `get_committee_details`, `get_detailed_member_information`, `list_ministerial_roles`, `search_members`. One flaky upstream endpoint now degrades gracefully (the failed section is logged and dropped) instead of sinking the entire tool. `get_committee_document` keeps fail-fast on purpose — it delivers explicitly-requested documents, where partial silent under-delivery is worse than a visible error.

## Why `gather` not `TaskGroup`

`TaskGroup` is fail-fast structured concurrency (one task raises → cancel the group). These tools fan out *independent* fetches and want partial results, which is exactly what `asyncio.gather(..., return_exceptions=True)` provides.

## Note for consumers

A tool failure is now reported via the MCP `isError` flag instead of as text content. Some MCP clients ignore `isError` and will surface the error message as ordinary tool output unless they check the flag explicitly.

## Testing

- New `tests/mcp_server/test_utils.py` (no Docker): `gather_sections` partial-failure contract + `extract_party_info` edge cases.
- Added committee 97 (null `purpose`) as a regression case to `test_get_committee_details`.
- Verified against the live Parliament APIs: all four tools succeed, and injecting a failure into one section drops only that section while the rest survive.